### PR TITLE
Fix issue #8 - CC changes after PC not working

### DIFF
--- a/src/fileio.C
+++ b/src/fileio.C
@@ -520,8 +520,7 @@ void RKR::getbuf(char *buf, int j)
 {
     switch (j)
     {
-    case 8:
-        //Reverb
+    case FX_Reverb:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Rev->getpar(0), efx_Rev->getpar(1),
                 efx_Rev->getpar(2), efx_Rev->getpar(3),
@@ -531,8 +530,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Rev->getpar(10), efx_Rev->getpar(11), Reverb_Bypass);
         break;
 
-    case 4:
-        //Echo
+    case FX_Echo:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Echo->getpar(0), efx_Echo->getpar(1),
                 efx_Echo->getpar(2), efx_Echo->getpar(3),
@@ -541,8 +539,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Echo->getpar(8), Echo_Bypass);
         break;
 
-    case 5:
-        //Chorus
+    case FX_Chorus:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Chorus->getpar(0), efx_Chorus->getpar(1),
                 efx_Chorus->getpar(2), efx_Chorus->getpar(3),
@@ -553,8 +550,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Chorus->getpar(12), Chorus_Bypass);
         break;
 
-    case 7:
-        //Flanger
+    case FX_Flanger:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Flanger->getpar(0), efx_Flanger->getpar(1),
                 efx_Flanger->getpar(2), efx_Flanger->getpar(3),
@@ -565,8 +561,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Flanger->getpar(12), Flanger_Bypass);
         break;
 
-    case 6:
-        //Phaser
+    case FX_Phaser:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Phaser->getpar(0), efx_Phaser->getpar(1),
                 efx_Phaser->getpar(2), efx_Phaser->getpar(3),
@@ -577,8 +572,7 @@ void RKR::getbuf(char *buf, int j)
                 Phaser_Bypass);
         break;
 
-    case 3:
-        //Overdrive
+    case FX_Overdrive:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Overdrive->getpar(0), efx_Overdrive->getpar(1),
                 efx_Overdrive->getpar(2), efx_Overdrive->getpar(3),
@@ -589,8 +583,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Overdrive->getpar(12), Overdrive_Bypass);
         break;
 
-    case 2:
-        //Distorsion
+    case FX_Distortion:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Distorsion->getpar(0), efx_Distorsion->getpar(1),
                 efx_Distorsion->getpar(2), efx_Distorsion->getpar(3),
@@ -601,8 +594,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Distorsion->getpar(12), Distorsion_Bypass);
         break;
 
-    case 0:
-        //EQ1
+    case FX_EQ1:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_EQ1->getpar(12), efx_EQ1->getpar(5 + 12),
                 efx_EQ1->getpar(10 + 12), efx_EQ1->getpar(15 + 12),
@@ -612,8 +604,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_EQ1->getpar(0), efx_EQ1->getpar(13), EQ1_Bypass);
         break;
 
-    case 9:
-        //EQ2
+    case FX_EQ2:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_EQ2->getpar(11), efx_EQ2->getpar(12),
                 efx_EQ2->getpar(13), efx_EQ2->getpar(5 + 11),
@@ -623,8 +614,7 @@ void RKR::getbuf(char *buf, int j)
                 EQ2_Bypass);
         break;
 
-    case 1:
-        // Compressor
+    case FX_Compressor:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Compressor->getpar(1), efx_Compressor->getpar(2),
                 efx_Compressor->getpar(3), efx_Compressor->getpar(4),
@@ -634,8 +624,7 @@ void RKR::getbuf(char *buf, int j)
         break;
 
 
-    case 10:
-        //WhaWha
+    case FX_WahWah:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_WhaWha->getpar(0), efx_WhaWha->getpar(1),
                 efx_WhaWha->getpar(2), efx_WhaWha->getpar(3),
@@ -645,8 +634,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_WhaWha->Ppreset, WhaWha_Bypass);
         break;
 
-    case 11:
-        //Alienwah
+    case FX_Alienwah:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Alienwah->getpar(0), efx_Alienwah->getpar(1),
                 efx_Alienwah->getpar(2), efx_Alienwah->getpar(3),
@@ -656,14 +644,12 @@ void RKR::getbuf(char *buf, int j)
                 efx_Alienwah->getpar(10), Alienwah_Bypass);
         break;
 
-    case 12:
-        //Cabinet
+    case FX_Cabinet:
         sprintf(buf, "%d,%d,%d\n",
                 efx_Cabinet->Cabinet_Preset, efx_Cabinet->getpar(0), Cabinet_Bypass);
         break;
 
-    case 13:
-        //Pan
+    case FX_Pan:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Pan->getpar(0), efx_Pan->getpar(1),
                 efx_Pan->getpar(2), efx_Pan->getpar(3),
@@ -672,8 +658,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Pan->getpar(8), Pan_Bypass);
         break;
 
-    case 14:
-        //Harmonizer
+    case FX_Harmonizer:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Har->getpar(0), efx_Har->getpar(1),
                 efx_Har->getpar(2), efx_Har->getpar(3),
@@ -683,8 +668,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Har->getpar(10), Harmonizer_Bypass);
         break;
 
-    case 15:
-        //MusicalDelay
+    case FX_MusDelay:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_MusDelay->getpar(0), efx_MusDelay->getpar(1),
                 efx_MusDelay->getpar(2), efx_MusDelay->getpar(3),
@@ -695,8 +679,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_MusDelay->getpar(12), MusDelay_Bypass);
         break;
 
-    case 16:
-        //NoiseGate
+    case FX_Gate:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Gate->getpar(1), efx_Gate->getpar(2),
                 efx_Gate->getpar(3), efx_Gate->getpar(4),
@@ -704,8 +687,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Gate->getpar(7), Gate_Bypass);
         break;
 
-    case 17:
-        //Derelict
+    case FX_Derelict:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Derelict->getpar(0), efx_Derelict->getpar(1),
                 efx_Derelict->getpar(2), efx_Derelict->getpar(3),
@@ -716,8 +698,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Derelict->getpar(12), Derelict_Bypass);
         break;
 
-    case 18:
-        //Analog Phaser
+    case FX_APhaser:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_APhaser->getpar(0), efx_APhaser->getpar(1),
                 efx_APhaser->getpar(2), efx_APhaser->getpar(3),
@@ -728,8 +709,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_APhaser->getpar(12), APhaser_Bypass);
         break;
 
-    case 19:
-        //Valve
+    case FX_Valve:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Valve->getpar(0), efx_Valve->getpar(1),
                 efx_Valve->getpar(2), efx_Valve->getpar(3),
@@ -740,8 +720,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Valve->getpar(12), Valve_Bypass);
         break;
 
-    case 20:
-        //Dual_Flange
+    case FX_DFlange:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_DFlange->getpar(0), efx_DFlange->getpar(1),
                 efx_DFlange->getpar(2), efx_DFlange->getpar(3),
@@ -753,8 +732,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_DFlange->getpar(14), DFlange_Bypass);
         break;
 
-    case 21:
-        //Ring
+    case FX_Ring:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Ring->getpar(0), efx_Ring->getpar(1),
                 efx_Ring->getpar(2), efx_Ring->getpar(3),
@@ -765,8 +743,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Ring->getpar(12), Ring_Bypass);
         break;
 
-    case 22:
-        //Exciter
+    case FX_Exciter:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Exciter->getpar(0), efx_Exciter->getpar(1),
                 efx_Exciter->getpar(2), efx_Exciter->getpar(3),
@@ -777,8 +754,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Exciter->getpar(12), Exciter_Bypass);
         break;
 
-    case 23:
-        //DistBand
+    case FX_DistBand:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_DistBand->getpar(0), efx_DistBand->getpar(1),
                 efx_DistBand->getpar(2), efx_DistBand->getpar(3),
@@ -790,8 +766,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_DistBand->getpar(14), DistBand_Bypass);
         break;
 
-    case 24:
-        //Arpie
+    case FX_Arpie:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Arpie->getpar(0), efx_Arpie->getpar(1),
                 efx_Arpie->getpar(2), efx_Arpie->getpar(3),
@@ -801,8 +776,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Arpie->getpar(10), Arpie_Bypass);
         break;
 
-    case 25:
-        //Expander
+    case FX_Expander:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Expander->getpar(1), efx_Expander->getpar(2),
                 efx_Expander->getpar(3), efx_Expander->getpar(4),
@@ -810,8 +784,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Expander->getpar(7), Expander_Bypass);
         break;
 
-    case 26:
-        //Shuffle
+    case FX_Shuffle:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Shuffle->getpar(0), efx_Shuffle->getpar(1),
                 efx_Shuffle->getpar(2), efx_Shuffle->getpar(3),
@@ -821,8 +794,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Shuffle->getpar(10), Shuffle_Bypass);
         break;
 
-    case 27:
-        //Synthfilter
+    case FX_Synthfilter:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Synthfilter->getpar(0), efx_Synthfilter->getpar(1),
                 efx_Synthfilter->getpar(2), efx_Synthfilter->getpar(3),
@@ -835,8 +807,7 @@ void RKR::getbuf(char *buf, int j)
                 Synthfilter_Bypass);
         break;
 
-    case 28:
-        //VaryBand
+    case FX_VaryBand:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_VaryBand->getpar(0), efx_VaryBand->getpar(1),
                 efx_VaryBand->getpar(2), efx_VaryBand->getpar(3),
@@ -846,8 +817,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_VaryBand->getpar(10), VaryBand_Bypass);
         break;
 
-    case 29:
-        //Convolotron
+    case FX_Convolotron:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%s\n",
                 efx_Convol->getpar(0), efx_Convol->getpar(1),
                 efx_Convol->getpar(2), efx_Convol->getpar(3),
@@ -857,8 +827,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Convol->getpar(10), Convol_Bypass, efx_Convol->Filename);
         break;
 
-    case 30:
-        //Looper
+    case FX_Looper:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Looper->getpar(0), efx_Looper->getpar(1),
                 efx_Looper->getpar(2), efx_Looper->getpar(3),
@@ -869,8 +838,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Looper->getpar(12), efx_Looper->getpar(13), Looper_Bypass);
         break;
 
-    case 31:
-        //MuTroMojo
+    case FX_MuTroMojo:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_MuTroMojo->getpar(0), efx_MuTroMojo->getpar(1),
                 efx_MuTroMojo->getpar(2), efx_MuTroMojo->getpar(3),
@@ -884,8 +852,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_MuTroMojo->getpar(18), MuTroMojo_Bypass);
 
         break;
-    case 32:
-        //Echoverse
+    case FX_Echoverse:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Echoverse->getpar(0), efx_Echoverse->getpar(1),
                 efx_Echoverse->getpar(2), efx_Echoverse->getpar(3),
@@ -896,8 +863,7 @@ void RKR::getbuf(char *buf, int j)
 
 
 
-    case 33:
-        //CoilCrafter
+    case FX_CoilCrafter:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_CoilCrafter->getpar(0), efx_CoilCrafter->getpar(1),
                 efx_CoilCrafter->getpar(2), efx_CoilCrafter->getpar(3),
@@ -906,16 +872,14 @@ void RKR::getbuf(char *buf, int j)
                 efx_CoilCrafter->getpar(8), CoilCrafter_Bypass);
         break;
 
-    case 34:
-        //ShelfBoost
+    case FX_ShelfBoost:
         sprintf(buf, "%d,%d,%d,%d,%d,%d\n",
                 efx_ShelfBoost->getpar(0), efx_ShelfBoost->getpar(1),
                 efx_ShelfBoost->getpar(2), efx_ShelfBoost->getpar(3),
                 efx_ShelfBoost->getpar(4), ShelfBoost_Bypass);
         break;
 
-    case 35:
-        //Vocoder
+    case FX_Vocoder:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Vocoder->getpar(0), efx_Vocoder->getpar(1),
                 efx_Vocoder->getpar(2), efx_Vocoder->getpar(3),
@@ -923,15 +887,13 @@ void RKR::getbuf(char *buf, int j)
                 efx_Vocoder->getpar(6), Vocoder_Bypass);
         break;
 
-    case 36:
-        //Sustainer
+    case FX_Sustainer:
         sprintf(buf, "%d,%d,%d\n",
                 efx_Sustainer->getpar(0), efx_Sustainer->getpar(1),
                 Sustainer_Bypass);
         break;
 
-    case 37:
-        //Sequence
+    case FX_Sequence:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Sequence->getpar(0), efx_Sequence->getpar(1),
                 efx_Sequence->getpar(2), efx_Sequence->getpar(3),
@@ -943,8 +905,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Sequence->getpar(14), Sequence_Bypass);
         break;
 
-    case 38:
-        //Shifter
+    case FX_Shifter:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Shifter->getpar(0), efx_Shifter->getpar(1),
                 efx_Shifter->getpar(2), efx_Shifter->getpar(3),
@@ -954,8 +915,7 @@ void RKR::getbuf(char *buf, int j)
         break;
 
 
-    case 39:
-        //StompBox
+    case FX_StompBox:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d\n",
                 efx_StompBox->getpar(0), efx_StompBox->getpar(1),
                 efx_StompBox->getpar(2), efx_StompBox->getpar(3),
@@ -963,8 +923,7 @@ void RKR::getbuf(char *buf, int j)
                 StompBox_Bypass);
         break;
 
-    case 40:
-        //Reverbtron
+    case FX_Reverbtron:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%s\n",
                 efx_Reverbtron->getpar(0), efx_Reverbtron->getpar(1),
                 efx_Reverbtron->getpar(2), efx_Reverbtron->getpar(3),
@@ -977,8 +936,7 @@ void RKR::getbuf(char *buf, int j)
                 Reverbtron_Bypass, efx_Reverbtron->Filename);
         break;
 
-    case 41:
-        //Echotron
+    case FX_Echotron:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%s\n",
                 efx_Echotron->getpar(0), efx_Echotron->getpar(1),
                 efx_Echotron->getpar(2), efx_Echotron->getpar(3),
@@ -990,8 +948,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_Echotron->getpar(14), efx_Echotron->getpar(15),
                 Echotron_Bypass, efx_Echotron->Filename);
         break;
-    case 42:
-        //StereoHarm
+    case FX_StereoHarm:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_StereoHarm->getpar(0), efx_StereoHarm->getpar(1),
                 efx_StereoHarm->getpar(2), efx_StereoHarm->getpar(3),
@@ -1002,8 +959,7 @@ void RKR::getbuf(char *buf, int j)
                 StereoHarm_Bypass);
         break;
 
-    case 43:
-        //CompBand
+    case FX_CompBand:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_CompBand->getpar(0), efx_CompBand->getpar(1),
                 efx_CompBand->getpar(2), efx_CompBand->getpar(3),
@@ -1014,8 +970,7 @@ void RKR::getbuf(char *buf, int j)
                 efx_CompBand->getpar(12), CompBand_Bypass);
         break;
 
-    case 44:
-        //Opticaltrem
+    case FX_OpticalTrem:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Opticaltrem->getpar(0), efx_Opticaltrem->getpar(1),
                 efx_Opticaltrem->getpar(2), efx_Opticaltrem->getpar(3),
@@ -1024,8 +979,7 @@ void RKR::getbuf(char *buf, int j)
         break;
 
 
-    case 45:
-        //Vibe
+    case FX_Vibe:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Vibe->getpar(0), efx_Vibe->getpar(1),
                 efx_Vibe->getpar(2), efx_Vibe->getpar(3),
@@ -1035,8 +989,7 @@ void RKR::getbuf(char *buf, int j)
                 Vibe_Bypass);
         break;
 
-    case 46:
-        //Infinity
+    case FX_Infinity:
         sprintf(buf, "%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                 efx_Infinity->getpar(0), efx_Infinity->getpar(1),
                 efx_Infinity->getpar(2), efx_Infinity->getpar(3),
@@ -1356,7 +1309,7 @@ RKR::Actualizar_Audio()
         switch (j)
         {
 
-        case 0: //EQ1
+        case FX_EQ1:
             EQ1_Bypass = 0;
             efx_EQ1->cleanup();
             for (i = 0; i < 10; i++)
@@ -1368,7 +1321,7 @@ RKR::Actualizar_Audio()
             EQ1_Bypass = EQ1_B;
             break;
 
-        case 1:// Compressor
+        case FX_Compressor:
             Compressor_Bypass = 0;
             efx_Compressor->cleanup();
             for (i = 0; i <= 9; i++)
@@ -1376,7 +1329,7 @@ RKR::Actualizar_Audio()
             Compressor_Bypass = Compressor_B;
             break;
 
-        case 2://Distortion
+        case FX_Distortion:
 
             Distorsion_Bypass = 0;
             efx_Distorsion->cleanup();
@@ -1385,7 +1338,7 @@ RKR::Actualizar_Audio()
             Distorsion_Bypass = Distorsion_B;
             break;
 
-        case 3://Overdrive
+        case FX_Overdrive:
 
             Overdrive_Bypass = 0;
             efx_Overdrive->cleanup();
@@ -1394,7 +1347,7 @@ RKR::Actualizar_Audio()
             Overdrive_Bypass = Overdrive_B;
             break;
 
-        case 4://Echo
+        case FX_Echo:
 
             Echo_Bypass = 0;
             efx_Echo->cleanup();
@@ -1403,34 +1356,34 @@ RKR::Actualizar_Audio()
             Echo_Bypass = Echo_B;
             break;
 
-        case 5://Chorus
+        case FX_Chorus:
 
             Chorus_Bypass = 0;
             efx_Chorus->cleanup();
             for (i = 0; i <= 12; i++)
-                efx_Chorus->changepar(i, lv[2][i]);
+                if (canset(j, i)) efx_Chorus->changepar(i, lv[2][i]);
             Chorus_Bypass = Chorus_B;
             break;
 
-        case 6://Phaser
+        case FX_Phaser:
 
             Phaser_Bypass = 0;
             efx_Phaser->cleanup();
             for (i = 0; i <= 11; i++)
-                efx_Phaser->changepar(i, lv[4][i]);
+                if (canset(j, i)) efx_Phaser->changepar(i, lv[4][i]);
             Phaser_Bypass = Phaser_B;
             break;
 
-        case 7://Flanger
+        case FX_Flanger:
 
             Flanger_Bypass = 0;
             efx_Flanger->cleanup();
             for (i = 0; i <= 12; i++)
-                efx_Flanger->changepar(i, lv[3][i]);
+                if (canset(j, i)) efx_Flanger->changepar(i, lv[3][i]);
             Flanger_Bypass = Flanger_B;
             break;
 
-        case 8://Reverb
+        case FX_Reverb:
 
             Reverb_Bypass = 0;
             efx_Rev->cleanup();
@@ -1439,7 +1392,7 @@ RKR::Actualizar_Audio()
             Reverb_Bypass = Reverb_B;
             break;
 
-        case 9://EQ2
+        case FX_EQ2:
 
             EQ2_Bypass = 0;
             efx_EQ2->cleanup();
@@ -1453,26 +1406,26 @@ RKR::Actualizar_Audio()
             EQ2_Bypass = EQ2_B;
             break;
 
-        case 10://WhaWha
+        case FX_WahWah:
 
             WhaWha_Bypass = 0;
             efx_WhaWha->cleanup();
             efx_WhaWha->setpreset(lv[11][10]);
             for (i = 0; i <= 9; i++)
-                efx_WhaWha->changepar(i, lv[11][i]);
+                if (canset(j, i)) efx_WhaWha->changepar(i, lv[11][i]);
             WhaWha_Bypass = WhaWha_B;
             break;
 
-        case 11://Alienwah
+        case FX_Alienwah:
 
             Alienwah_Bypass = 0;
             efx_Alienwah->cleanup();
             for (i = 0; i <= 10; i++)
-                efx_Alienwah->changepar(i, lv[12][i]);
+                if (canset(j, i)) efx_Alienwah->changepar(i, lv[12][i]);
             Alienwah_Bypass = Alienwah_B;
             break;
 
-        case 12://Cabinet
+        case FX_Cabinet:
 
             Cabinet_Bypass = 0;
             efx_Cabinet->cleanup();
@@ -1481,7 +1434,7 @@ RKR::Actualizar_Audio()
             Cabinet_Bypass = Cabinet_B;
             break;
 
-        case 13://Pan
+        case FX_Pan:
 
             Pan_Bypass = 0;
             efx_Pan->cleanup();
@@ -1490,7 +1443,7 @@ RKR::Actualizar_Audio()
             Pan_Bypass = Pan_B;
             break;
 
-        case 14://Harmonizer
+        case FX_Harmonizer:
 
             Harmonizer_Bypass = 0;
             efx_Har->cleanup();
@@ -1499,16 +1452,16 @@ RKR::Actualizar_Audio()
             Harmonizer_Bypass = Harmonizer_B;
             break;
 
-        case 15://MusDelay
+        case FX_MusDelay:
 
             MusDelay_Bypass = 0;
             efx_MusDelay->cleanup();
             for (i = 0; i <= 12; i++)
-                efx_MusDelay->changepar(i, lv[16][i]);
+                if (canset(j, i)) efx_MusDelay->changepar(i, lv[16][i]);
             MusDelay_Bypass = MusDelay_B;
             break;
 
-        case 16://Gate
+        case FX_Gate:
 
             Gate_Bypass = 0;
             efx_Gate->cleanup();
@@ -1517,7 +1470,7 @@ RKR::Actualizar_Audio()
             Gate_Bypass = Gate_B;
             break;
 
-        case 17://Derelict
+        case FX_Derelict:
 
             Derelict_Bypass = 0;
             efx_Derelict->cleanup();
@@ -1526,7 +1479,7 @@ RKR::Actualizar_Audio()
             Derelict_Bypass = Derelict_B;
             break;
 
-        case 18://APhaser
+        case FX_APhaser:
 
             APhaser_Bypass = 0;
             efx_APhaser->cleanup();
@@ -1535,7 +1488,7 @@ RKR::Actualizar_Audio()
             APhaser_Bypass = APhaser_B;
             break;
 
-        case 19://Valve
+        case FX_Valve:
 
             Valve_Bypass = 0;
             efx_Valve->cleanup();
@@ -1544,7 +1497,7 @@ RKR::Actualizar_Audio()
             Valve_Bypass = Valve_B;
             break;
 
-        case 20://DFlange
+        case FX_DFlange:
 
             DFlange_Bypass = 0;
             efx_DFlange->cleanup();
@@ -1553,7 +1506,7 @@ RKR::Actualizar_Audio()
             DFlange_Bypass = DFlange_B;
             break;
 
-        case 21://Ring
+        case FX_Ring:
 
             Ring_Bypass = 0;
             efx_Ring->cleanup();
@@ -1562,7 +1515,7 @@ RKR::Actualizar_Audio()
             Ring_Bypass = Ring_B;
             break;
 
-        case 22://Exciter
+        case FX_Exciter:
 
             Exciter_Bypass = 0;
             efx_Exciter->cleanup();
@@ -1571,7 +1524,7 @@ RKR::Actualizar_Audio()
             Exciter_Bypass = Exciter_B;
             break;
 
-        case 23://DistBand
+        case FX_DistBand:
 
             DistBand_Bypass = 0;
             efx_DistBand->cleanup();
@@ -1580,7 +1533,7 @@ RKR::Actualizar_Audio()
             DistBand_Bypass = DistBand_B;
             break;
 
-        case 24://Arpie
+        case FX_Arpie:
 
             Arpie_Bypass = 0;
             efx_Arpie->cleanup();
@@ -1589,7 +1542,7 @@ RKR::Actualizar_Audio()
             Arpie_Bypass = Arpie_B;
             break;
 
-        case 25://Expander
+        case FX_Expander:
 
             Expander_Bypass = 0;
             efx_Expander->cleanup();
@@ -1598,7 +1551,7 @@ RKR::Actualizar_Audio()
             Expander_Bypass = Expander_B;
             break;
 
-        case 26://Shuffle
+        case FX_Shuffle:
 
             Shuffle_Bypass = 0;
             efx_Shuffle->cleanup();
@@ -1607,7 +1560,7 @@ RKR::Actualizar_Audio()
             Shuffle_Bypass = Shuffle_B;
             break;
 
-        case 27://Synthfilter
+        case FX_Synthfilter:
 
             Synthfilter_Bypass = 0;
             efx_Synthfilter->cleanup();
@@ -1616,7 +1569,7 @@ RKR::Actualizar_Audio()
             Synthfilter_Bypass = Synthfilter_B;
             break;
 
-        case 28://VaryBand
+        case FX_VaryBand:
 
             VaryBand_Bypass = 0;
             efx_VaryBand->cleanup();
@@ -1625,7 +1578,7 @@ RKR::Actualizar_Audio()
             VaryBand_Bypass = VaryBand_B;
             break;
 
-        case 29://Convolotron
+        case FX_Convolotron:
 
             Convol_Bypass = 0;
             efx_Convol->cleanup();
@@ -1634,7 +1587,7 @@ RKR::Actualizar_Audio()
             Convol_Bypass = Convol_B;
             break;
 
-        case 30://Looper
+        case FX_Looper:
 
             Looper_Bypass = 0;
             // efx_Looper->cleanup();
@@ -1643,7 +1596,7 @@ RKR::Actualizar_Audio()
             Looper_Bypass = Looper_B;
             break;
 
-        case 31://MuTroMojo
+        case FX_MuTroMojo:
 
             MuTroMojo_Bypass = 0;
             efx_MuTroMojo->cleanup();
@@ -1652,7 +1605,7 @@ RKR::Actualizar_Audio()
             MuTroMojo_Bypass = MuTroMojo_B;
             break;
 
-        case 32://Echoverse
+        case FX_Echoverse:
 
             Echoverse_Bypass = 0;
             efx_Echoverse->cleanup();
@@ -1661,7 +1614,7 @@ RKR::Actualizar_Audio()
             Echoverse_Bypass = Echoverse_B;
             break;
 
-        case 33://CoilCrafter
+        case FX_CoilCrafter:
 
             CoilCrafter_Bypass = 0;
             efx_CoilCrafter->cleanup();
@@ -1670,7 +1623,7 @@ RKR::Actualizar_Audio()
             CoilCrafter_Bypass = CoilCrafter_B;
             break;
 
-        case 34://ShelfBoost
+        case FX_ShelfBoost:
 
             ShelfBoost_Bypass = 0;
             efx_ShelfBoost->cleanup();
@@ -1679,7 +1632,7 @@ RKR::Actualizar_Audio()
             ShelfBoost_Bypass = ShelfBoost_B;
             break;
 
-        case 35://Vocoder
+        case FX_Vocoder:
 
             Vocoder_Bypass = 0;
             efx_Vocoder->cleanup();
@@ -1688,7 +1641,7 @@ RKR::Actualizar_Audio()
             Vocoder_Bypass = Vocoder_B;
             break;
 
-        case 36://Sustainer
+        case FX_Sustainer:
 
             Sustainer_Bypass = 0;
             efx_Sustainer->cleanup();
@@ -1697,7 +1650,7 @@ RKR::Actualizar_Audio()
             Sustainer_Bypass = Sustainer_B;
             break;
 
-        case 37://Sequence
+        case FX_Sequence:
 
             Sequence_Bypass = 0;
             efx_Sequence->cleanup();
@@ -1706,7 +1659,7 @@ RKR::Actualizar_Audio()
             Sequence_Bypass = Sequence_B;
             break;
 
-        case 38://Shifter
+        case FX_Shifter:
 
             Shifter_Bypass = 0;
             efx_Shifter->cleanup();
@@ -1715,7 +1668,7 @@ RKR::Actualizar_Audio()
             Shifter_Bypass = Shifter_B;
             break;
 
-        case 39://StompBox
+        case FX_StompBox:
 
             StompBox_Bypass = 0;
             efx_StompBox->cleanup();
@@ -1724,7 +1677,7 @@ RKR::Actualizar_Audio()
             StompBox_Bypass = StompBox_B;
             break;
 
-        case 40://Reverbtron
+        case FX_Reverbtron:
 
             Reverbtron_Bypass = 0;
             efx_Reverbtron->cleanup();
@@ -1733,7 +1686,7 @@ RKR::Actualizar_Audio()
             Reverbtron_Bypass = Reverbtron_B;
             break;
 
-        case 41://Echotron
+        case FX_Echotron:
 
             Echotron_Bypass = 0;
             efx_Echotron->cleanup();
@@ -1742,7 +1695,7 @@ RKR::Actualizar_Audio()
             Echotron_Bypass = Echotron_B;
             break;
 
-        case 42://StereoHarm
+        case FX_StereoHarm:
 
             StereoHarm_Bypass = 0;
             efx_StereoHarm->cleanup();
@@ -1752,7 +1705,7 @@ RKR::Actualizar_Audio()
             StereoHarm_Bypass = StereoHarm_B;
             break;
 
-        case 43://CompBand
+        case FX_CompBand:
 
             CompBand_Bypass = 0;
             efx_CompBand->cleanup();
@@ -1761,7 +1714,7 @@ RKR::Actualizar_Audio()
             CompBand_Bypass = CompBand_B;
             break;
 
-        case 44://OpticalTrem
+        case FX_OpticalTrem:
 
             Opticaltrem_Bypass = 0;
             efx_Opticaltrem->cleanup();
@@ -1770,7 +1723,7 @@ RKR::Actualizar_Audio()
             Opticaltrem_Bypass = Opticaltrem_B;
             break;
 
-        case 45://Vibe
+        case FX_Vibe:
 
             Vibe_Bypass = 0;
             efx_Vibe->cleanup();
@@ -1779,7 +1732,7 @@ RKR::Actualizar_Audio()
             Vibe_Bypass = Vibe_B;
             break;
 
-        case 46://Infinity
+        case FX_Infinity:
 
             Infinity_Bypass = 0;
             efx_Infinity->cleanup();
@@ -2175,7 +2128,8 @@ RKR::Bank_to_Preset(int i)
     if (actuvol == 0)
     {
         Input_Gain = Bank[i].Input_Gain;
-        Master_Volume = Bank[i].Master_Volume;
+        if (canset(FX_Main, Parm_Volume))
+            Master_Volume = Bank[i].Master_Volume;
         Fraction_Bypass = Bank[i].Balance;
     }
 
@@ -2183,6 +2137,10 @@ RKR::Bank_to_Preset(int i)
     {
         Update_tempo();
     }
+
+    /* Clear all of the preserved flags: these parameters will no longer be
+       preserved until the next time a preset change is initiated. */
+    clear_preserved();
 }
 
 void

--- a/src/global.h
+++ b/src/global.h
@@ -217,6 +217,7 @@ const unsigned c_rkr_ext_size = 4;
 
 //TODO: move these values into the RKR object
 extern int Pexitprogram, preset;
+extern int preserve;  // See the PRSRV_* constants below.
 extern int commandline, gui;
 extern int exitwithhelp, nojack;
 extern int error_num;
@@ -242,6 +243,492 @@ const int C_DONT_CHANGE_FONT_SIZE = 0;
    is not real time safe. */
 const unsigned C_MILLISECONDS_25 = 250000;   // 1/4 second
 const unsigned C_MILLISECONDS_50 = 500000;   // 1/2 second
+
+/* Each effect has a unique numeric identifier. */
+enum EffectIndex {
+    FX_EQ1 = 0,
+    FX_Compressor,
+    FX_Distortion,
+    FX_Overdrive,
+    FX_Echo,
+    FX_Chorus,
+    FX_Phaser,
+    FX_Flanger,
+    FX_Reverb,
+    FX_EQ2,
+    FX_WahWah,
+    FX_Alienwah,
+    FX_Cabinet,
+    FX_Pan,
+    FX_Harmonizer,
+    FX_MusDelay,
+    FX_Gate,
+    FX_Derelict,
+    FX_APhaser,
+    FX_Valve,
+    FX_DFlange,
+    FX_Ring,
+    FX_Exciter,
+    FX_DistBand,
+    FX_Arpie,
+    FX_Expander,
+    FX_Shuffle,
+    FX_Synthfilter,
+    FX_VaryBand,
+    FX_Convolotron,
+    FX_Looper,
+    FX_MuTroMojo,
+    FX_Echoverse,
+    FX_CoilCrafter,
+    FX_ShelfBoost,
+    FX_Vocoder,
+    FX_Sustainer,
+    FX_Sequence,
+    FX_Shifter,
+    FX_StompBox,
+    FX_Reverbtron,
+    FX_Echotron,
+    FX_StereoHarm,
+    FX_CompBand,
+    FX_OpticalTrem,
+    FX_Vibe,
+    FX_Infinity,
+
+    /* "Main" isn't really an affect, we just use this to reference global
+       settings like master volume and gain.  It must be the last element in
+       the enum. */
+    FX_Main
+};
+
+const int FXCount = FX_Main + 1;
+
+/* Parameter index. */
+enum ParmIndex {
+    // Exciter, CoilCrafter, ShelfBoost, Sustainer, StompBox, EQ1/EQ2/Cabinet
+    Parm_Volume = 0,
+
+    // WahWah, Distortion/Overdrive, Harmonizer, Chorus/Flanger, Phaser,
+    // Alienwah, MusDelay, Reverb, Pan, Echo, Derelict, Valve, Ring, DistBand,
+    // Arpie, Convolotron, Vocoder, Echoverse, Shifter, DFlange
+    Parm_Pan = 1,
+
+    // WahWah, Distortion/Overdrive, Harmonizer, Chorus/Flanger, Phaser,
+    // Alienwah, MusDelay, Reverb, Pan, Echo, Derelict
+    // APhaser, Valve, Ring, DistBand, Arpie, Shuffle, Synthfilter, VaryBand,
+    // MuTroMojo, Looper, Convolotron, Vocoder, Echoverse, Shifter,
+    // Reverbtron, Echotron, StereoHarm, CompBand, Infinity, DFlange
+    Parm_DryWet = 0,
+
+    // Chorus/Flanger, Phaser, WahWah, Alienwah, Distortion/Overdrive, APhaser,
+    // Synthfilter, MuTroMojo, Pan
+    Parm_LFOFreq = 2,
+
+    // Distortion/Overdrive, Derelict, Valve, DistBand
+    Parm_Drive = 3,
+    Parm_Level = 4,
+
+    // Distortion/Overdrive, Derelict, DFlange, Valve, Ring, DistBand
+    Parm_Dist_LRCross = 2,
+
+    // Distortion/Overdrive, Reverb, Derelict
+    Parm_LowPassFilter = 7,
+    Parm_HighPassFilter = 8,
+
+    // Distortion/Overdrive
+    Parm_Dist_Octave = 12,
+
+    // Distortion/Overdrive, Derelict
+    Parm_Distortion_Type = 5,
+
+    // Harmonizer
+    Parm_Interval = 3,
+    Parm_Freq = 4,
+    Parm_Note = 6,
+    Parm_FGain = 8,
+    Parm_Harmonizer_Type = 7,
+    Parm_Harmonizer_Select = 5,
+
+    // Chorus/Flanger, Phaser, Alienwah, Vibe
+    Parm_LRCross = 9,
+
+    // Echo, MusDelay, Arpie, Echoverse
+    Parm_Feedback = 5,
+
+    // Echo, Arpie, MusDelay, Echoverse
+    Parm_Echo_LRCross = 4,
+
+    // WahWah, Alienwah, Phaser, Flanger/Chorus, MuTroMojo
+    Parm_Depth = 6,
+
+    // WahWah
+    Parm_AmpSns = 7,
+    Parm_AmpSnsNS = 8,
+    Parm_AmpSnsSmooth = 9,
+
+    // Phaser, Alienwah, APhaser, Synthfilter, Vibe
+    Parm_Phaser_Feedback = 7,
+
+    // Phaser
+    Parm_Phase = 11,
+
+    // Alienwah
+    Parm_Alien_Phase = 10,
+    Parm_Alien_Delay = 8,
+
+    // Chorus/Flanger
+    Parm_Chorus_Feedback = 8,
+    Parm_Chorus_Delay = 7,
+
+    // Chorus/Flanger, Alienwah, APhaser, MuTroMojo, Pan, Phaser, Synthfilter,
+    // WahWah
+    Parm_LFOType = 4,
+
+    // Chorus/Flanger, Phaser, Alienwah, APhaser, Synthfilter, MuTroMojo,
+    // WahWah, Pan
+    Parm_LFOStereo = 5,
+
+    // Chorus/Flanger, Phaser, WahWah, Alienwah, APhaser, MuTroMojo,
+    // Synthfilter, Pan
+    Parm_LFORandomness = 3,
+
+    // MusDelay
+    Parm_MusDelay_Feedback2 = 9,
+
+    // MusDelay
+    Parm_Pan2 = 7,
+    Parm_Gain1 = 11,
+    Parm_Gain2 = 12,
+    Parm_MusDelay_Tempo = 10,
+
+    // DFlange
+    Parm_DFlange_Depth = 3,
+    Parm_DFlange_Width = 4,
+    Parm_DFlange_Offset = 5,
+    Parm_DFlange_Feedback = 6,
+    Parm_DFlange_HiDamp = 7,
+    Parm_DFlange_LFOFreq = 10,
+    Parm_DFlange_LFOStereo = 11,
+    Parm_DFlange_LFOType = 12,
+    Parm_DFlange_LFORandomness = 13,
+
+    // APhaser, Synthfilter
+    Parm_Distortion = 1,
+    Parm_Width = 6,
+    Parm_APhaser_Depth = 11,
+
+    // APhaser
+    Parm_Offset = 9,
+
+    // Derelict
+    Parm_RFreq = 9,
+    Parm_Octave = 11,
+
+    // Compressor, Gate
+    Parm_Threshold = 1,
+
+    // Compressor
+    Parm_Ratio = 2,
+    Parm_Output = 3,
+    Parm_AttTime = 4,
+    Parm_RelTime = 5,
+    Parm_Knee = 7,
+
+    // Main
+    Parm_FractionBypass = 1,
+
+    // Main, Shifter, StereoHarm, Harmonizer
+    Parm_InputGain = 2,
+
+    // Valve
+    Parm_Q = 10,
+    Parm_Presence = 12,
+    Parm_Valve_LowPass = 6,
+    Parm_Valve_HighPass = 7,
+
+    // Ring
+    Parm_Input = 11,
+    Parm_Ring_Level = 3,
+    Parm_Ring_Depth = 4,
+    Parm_Ring_Freq = 5,
+    Parm_Ring_Sine = 7,
+    Parm_Ring_Tri = 8,
+    Parm_Ring_Saw = 9,
+    Parm_Ring_Square = 10,
+
+    // Exciter
+    Parm_Exciter_LowPassFilter = 11,
+    Parm_Exciter_HighPassFilter = 12,
+    Parm_Exciter_H1 = 1,
+    Parm_Exciter_H2 = 2,
+    Parm_Exciter_H3 = 3,
+    Parm_Exciter_H4 = 4,
+    Parm_Exciter_H5 = 5,
+    Parm_Exciter_H6 = 6,
+    Parm_Exciter_H7 = 7,
+    Parm_Exciter_H8 = 8,
+    Parm_Exciter_H9 = 9,
+    Parm_Exciter_H10 = 10,
+
+    // DistBand
+    Parm_DistBand_TypeLow = 5,
+    Parm_DistBand_TypeMid = 6,
+    Parm_DistBand_TypeHigh = 7,
+    Parm_DistBand_LowVol = 8,
+    Parm_DistBand_MidVol = 9,
+    Parm_DistBand_HighVol = 10,
+    Parm_DistBand_Cross1 = 12,
+    Parm_DistBand_Cross2 = 13,
+
+    // Arpie, Echoverse, Echo
+    Parm_Arpie_Reverse = 7,
+
+    // Arpie
+    Parm_Arpie_Tempo = 2,
+
+    // Arpie, Echoverse, Echo
+    Parm_Arpie_LRDelay = 3,
+
+    // Arpie, Convolotron, Echoverse, Reverbtron, Echotron, Echo, MusDelay
+    Parm_Arpie_HiDamp = 6,
+
+    // Expander
+    Parm_Expander_Threshold = 1,
+    Parm_Expander_Shape = 2,
+    Parm_Expander_OutGain = 7,
+
+    // Expander, Gate
+    Parm_Expander_LowPassFilter = 5,
+    Parm_Expander_HighPassFilter = 6,
+
+    // Expander, Shifter, Gate
+    Parm_Expander_Attack = 3,
+    Parm_Expander_Decay = 4,
+
+    // Shuffle
+    Parm_Shuffle_GainLow = 1,
+    Parm_Shuffle_GainMidLow = 2,
+    Parm_Shuffle_GainMidHigh = 3,
+    Parm_Shuffle_GainHigh = 4,
+    Parm_Shuffle_Cross1 = 5,
+    Parm_Shuffle_Cross2 = 6,
+    Parm_Shuffle_Cross3 = 7,
+    Parm_Shuffle_Cross4 = 8,
+
+    // Shuffle, Infinity, Harmonizer
+    Parm_Shuffle_Q = 9,
+
+    // Synthfilter
+    Parm_Synthfilter_Envelope = 12,
+    Parm_Synthfilter_Attack = 13,
+    Parm_Synthfilter_Release = 14,
+    Parm_Synthfilter_Bandwidth = 15,
+
+    // VaryBand
+    Parm_VaryBand_LFOType = 2,
+    Parm_VaryBand_LFOStereo = 3,
+    Parm_VaryBand_LFO2Freq = 4,
+    Parm_VaryBand_LFO2Type = 5,
+    Parm_VaryBand_LFO2Stereo = 6,
+    Parm_VaryBand_Cross1 = 7,
+    Parm_VaryBand_Cross2 = 8,
+    Parm_VaryBand_Cross3 = 9,
+
+    // VaryBand, OpticalTrem, Vibe
+    Parm_VaryBand_LFOFreq = 1,
+
+    // MuTroMojo, ShelfBoost
+    Parm_MuTroMojo_Q = 1,
+
+    // MuTroMojo, Sequence
+    Parm_Range = 14,
+
+    // MuTroMojo,
+    Parm_MuTroMojo_AmpSns = 7,
+    Parm_MuTroMojo_AmpSnsInv = 8,
+    Parm_MuTroMojo_AmpSmooth = 9,
+    Parm_MuTroMojo_LowPassLvl = 10,
+    Parm_MuTroMojo_BandPassLvl = 11,
+    Parm_MuTroMojo_HighPassLvl = 12,
+    Parm_MuTroMojo_MinFreq = 15,
+
+    // Looper
+    Parm_Looper_Play = 1,
+    Parm_Looper_Stop = 2,
+    Parm_Looper_Record = 3,
+    Parm_Looper_Clear = 4,
+    Parm_Looper_Fade1 = 6,
+    Parm_Looper_Track1 = 7,
+    Parm_Looper_Track2 = 8,
+    Parm_Looper_Autoplay = 9,
+    Parm_Looper_Fade2 = 10,
+    Parm_Looper_Record1 = 11,
+    Parm_Looper_Record2 = 12,
+    Parm_Looper_Reverse = 5,
+    Parm_Looper_Tempo = 14,
+
+    // Convolotron, Reverbtron
+    Parm_Convolotron_Level = 7,
+
+    // Convolotron, Reverbtron, Echotron
+    Parm_Convolotron_Length = 3,
+    Parm_Convolotron_Feedback = 10,
+
+    // CoilCrafter
+    Parm_CoilCrafter_Freq1 = 3,
+    Parm_CoilCrafter_Q1 = 4,
+    Parm_CoilCrafter_Freq2 = 5,
+    Parm_CoilCrafter_Q2 = 6,
+    Parm_CoilCrafter_HighPassFilter = 7,
+
+    // ShelfBoost
+    Parm_ShelfBoost_Freq = 2,
+
+    // ShelfBoost, StompBox
+    Parm_ShelfBoost_Gain = 4,
+
+    // Vocoder
+    Parm_Vocoder_Muffle = 2,
+    Parm_Vocoder_Q = 3,
+    Parm_Vocoder_Input = 4,
+    Parm_Vocoder_Level = 5,
+    Parm_Vocoder_Ring = 6,
+
+    // Echoverse, Echo
+    Parm_Echoverse_Delay = 2,
+
+    // Echoverse
+    Parm_Echoverse_ExStereo = 9,
+
+    // Sustainer
+    Parm_Sustain = 1,
+
+    // Sequence
+    Parm_Sequence_1 = 0,
+    Parm_Sequence_2 = 1,
+    Parm_Sequence_3 = 2,
+    Parm_Sequence_4 = 3,
+    Parm_Sequence_5 = 4,
+    Parm_Sequence_6 = 5,
+    Parm_Sequence_7 = 6,
+    Parm_Sequence_8 = 7,
+    Parm_Sequence_DryWet = 8,
+    Parm_Sequence_Tempo = 9,
+    Parm_Sequence_Q = 10,
+    Parm_Sequence_Amp = 11,
+    Parm_Sequence_StereoDiff = 12,
+    Parm_Sequence_Mode = 13,
+
+    // Shifter
+    Parm_Shifter_Threshold = 5,
+    Parm_Shifter_Interval = 6,
+    Parm_Shifter_Whammy = 9,
+
+    // StompBox
+    Parm_StompBox_High = 1,
+    Parm_StompBox_Mid = 2,
+    Parm_StompBox_Low = 3,
+    Parm_StompBox_Mode = 5,
+
+    // Reverbtron
+    Parm_Reverbtron_Fade = 1,
+    Parm_Reverbtron_InitialDelay = 5,
+    Parm_Reverbtron_Stretch = 9,
+
+    // Reverbtron, Echotron
+    Parm_Reverbtron_Pan = 11,
+
+    // Echotron
+    Parm_Echotron_Depth = 1,
+    Parm_Echotron_Width = 2,
+    Parm_Echotron_Tempo = 5,
+    Parm_Echotron_LRCross = 7,
+    Parm_Echotron_LFOStereo = 9,
+    Parm_Echotron_LFOType = 14,
+
+    // StereoHarm
+    Parm_StereoHarm_GainLeft = 1,
+    Parm_StereoHarm_IntervalLeft = 2,
+    Parm_StereoHarm_ChromeLeft = 3,
+    Parm_StereoHarm_GainRight = 4,
+    Parm_StereoHarm_IntervalRight = 5,
+    Parm_StereoHarm_ChromeRight = 6,
+    Parm_StereoHarm_Select = 7,
+    Parm_StereoHarm_Note = 8,
+    Parm_StereoHarm_Type = 9,
+    Parm_StereoHarm_LRCross = 11,
+
+    // CompBand
+    Parm_CompBand_LowRatio = 1,
+    Parm_CompBand_MidLowRatio = 2,
+    Parm_CompBand_MidHighRatio = 3,
+    Parm_CompBand_HighRatio = 4,
+    Parm_CompBand_LowThreshold = 5,
+    Parm_CompBand_MidLowThreshold = 6,
+    Parm_CompBand_MidHighThreshold = 7,
+    Parm_CompBand_HighThreshold = 8,
+    Parm_CompBand_Cross1 = 9,
+    Parm_CompBand_Cross2 = 10,
+    Parm_CompBand_Cross3 = 11,
+    Parm_CompBand_Level = 12,
+
+    // OpticalTrem
+    Parm_OpticalTrem_Depth = 0,
+
+    // OpticalTrem, Vibe
+    Parm_OpticalTrem_LFOType = 3,
+
+    // OpticalTrem, Vibe
+    Parm_OpticalTrem_Randomness = 2,
+    Parm_OpticalTrem_LFOStereo = 4,
+    Parm_OpticalTrem_Pan = 5,
+
+    // Vibe
+    Parm_Vibe_Width = 0,
+    Parm_Vibe_DryWet = 6,
+    Parm_Vibe_Depth = 8,
+
+    // Infinity
+    Parm_Infinity_P1 = 1,
+    Parm_Infinity_P2 = 2,
+    Parm_Infinity_P3 = 3,
+    Parm_Infinity_P4 = 4,
+    Parm_Infinity_P5 = 5,
+    Parm_Infinity_P6 = 6,
+    Parm_Infinity_P7 = 7,
+    Parm_Infinity_P8 = 8,
+    Parm_Infinity_StartFreq = 10,
+    Parm_Infinity_EndFreq = 11,
+    Parm_Infinity_Rate = 12,
+    Parm_Infinity_StereoDiff = 13,
+    Parm_Infinity_Subdiv = 14,
+    Parm_Infinity_Autopan = 15,
+
+    // Gate
+    Parm_Gate_Range = 2,
+    Parm_Hold = 7,
+
+    // Pan
+    Parm_Extra = 6,
+
+    // Reverb
+    Parm_Reverb_Time = 2,
+    Parm_Reverb_InitialDelay = 3,
+    Parm_Reverb_DelayFeedback = 4,
+    Parm_Reverb_RoomSize = 11,
+    Parm_Reverb_LoHiDamp = 9,
+
+    // Reverbtron
+    Parm_Reverbtron_Diffusion = 15,
+    Parm_Reverbtron_LowPassFilter = 14,
+
+    /* This value is used to determine the size of the "preserve" array.  It
+       must be large enough to accommodate any parameter number used in a
+       changepar() method.  It's currently 63 because of the number of EQ
+       params. */
+    Parm_Last = 63
+};
+
+const int ParmCount = Parm_Last + 1;
 
 #endif
 

--- a/src/midicheck.py
+++ b/src/midicheck.py
@@ -1,0 +1,95 @@
+import re
+import os
+import subprocess
+
+globalsTimestamp = 0
+map = {}
+
+effectXlate = {
+    'Convol': 'Convolotron',
+    'Opticaltrem': 'OpticalTrem',
+    'Har': 'Harmonizer',
+    'Rev': 'Reverb',
+    'Distorsion': 'Distortion',
+    'WhaWha': 'WahWah',
+}
+
+COMMENT_RX = re.compile(r'\s*// (.*)')
+SEP_RX = re.compile(r'/|,\s*')
+PARM_RX = re.compile(r'\s*(\S+)\s*=\s*(\d+)\s*,')
+GLOBALS_FILE = '/home/mmuller/w2/rakarrack-plus/src/global.h'
+CHANGEPAR_RX = re.compile(r'([\-\+ ])(\s*)efx_(\S+)->changepar\((\S+),(.*)')
+PRESERVE_RX = re.compile(r'\+\s+preserve_parm\(FX_([^\s,]+), ([^\s,]+)\);')
+
+def parseGlobal():
+    inEnum = False
+    effects = []
+    gotParm = False
+    for line in open(GLOBALS_FILE):
+        if inEnum:
+            m = COMMENT_RX.match(line)
+            if m:
+                if gotParm:
+                    effects = SEP_RX.split(m.group(1).strip())
+                else:
+                    effects += SEP_RX.split(m.group(1).strip())
+                gotParm = False
+                continue
+
+            m = PARM_RX.match(line)
+            if m:
+                parm = m.group(1)
+                val = m.group(2)
+                for effect in effects:
+                    map[effect, val] = parm
+                gotParm = True
+                continue
+
+            if line == '};\n':
+                break
+
+        else:
+            if line == 'enum ParmIndex {\n':
+                inEnum = True
+
+def run():
+    parseGlobal()
+
+    # Initialize to the first values we use.
+    effect = 'Main'
+    parmEnum = 'Parm_Volume'
+
+    lineNum = 1
+    proc = subprocess.Popen(['git', 'diff', 'rkrMIDI.C'],
+                            stdout=subprocess.PIPE,
+                            bufsize=1)
+    lines = iter(proc.stdout.readline, b'')
+    for line in lines:
+        line = line.decode()
+        print(repr(line))
+        m = CHANGEPAR_RX.match(line)
+        if m:
+            effectVar = m.group(3)
+            effect = effectXlate.get(effectVar, effectVar)
+            parm = m.group(4)
+
+            if m.group(1) == '+':
+                parmEnum = map[effect, numericParm]
+                if parmEnum != parm:
+                    print(f'expected enum of {parmEnum}, got {parm}')
+                    raise Exception(f'failed at {lineNum}: {line}')
+            else:
+                numericParm = parm
+            continue
+
+        m = PRESERVE_RX.match(line)
+        if m:
+            if m.group(1) != effect and m.group(1) != 'Main':
+                raise Exception(f'error {lineNum}: bad effect: {line}')
+            if m.group(2) != parmEnum and \
+               m.group(1) not in ('Main', 'EQ1', 'EQ2'):
+                print(parmEnum)
+                raise Exception(f'error {lineNum}: bad param: {line}')
+        lineNum += 1
+
+run()

--- a/src/process.C
+++ b/src/process.C
@@ -441,6 +441,7 @@ RKR::RKR() :
     error_num = 0;
     nojack = 0;
     memset(Mcontrol, 0, sizeof (Mcontrol));
+    clear_preserved();
     sprintf(temp, "%s", jack_client_name);
 
 #ifdef JACK_SESSION

--- a/src/process.h
+++ b/src/process.h
@@ -660,8 +660,17 @@ public:
     } jack_po[16],jack_poi[16];
 
 
+    /* this array indicates that the value of a parameter should be preserved
+       after the next program change. */
+    bool preserve[FXCount][ParmCount];
 
-
+private:
+    void preserve_parm(EffectIndex effect, int parm);
+    inline bool canset(EffectIndex effect, ParmIndex parm) {
+        return !preserve[effect][parm];
+    }
+    bool canset(int effect, int parm);
+    void clear_preserved();
 };
 
 struct list_element

--- a/src/rkrMIDI.C
+++ b/src/rkrMIDI.C
@@ -947,6 +947,35 @@ RKR::jack_process_midievents(jack_midi_event_t *midievent)
     }
 }
 
+void
+RKR::preserve_parm(EffectIndex effect, int param) {
+    if (param > ParmCount) {
+        printf("ERROR: Parameter index %d out of range!", param);
+        return;
+    }
+    if (preset != 1000)
+        preserve[effect][param] = true;
+}
+
+void
+RKR::clear_preserved() {
+    memset(preserve, 0, sizeof (preserve));
+}
+
+bool
+RKR::canset(int effect, int parm) {
+    if (effect < 0 || effect > FXCount) {
+        printf("ERROR: Effect index %d out of range.", effect);
+        return true;
+    }
+    if (parm < 0 || parm >= ParmCount) {
+        printf("ERROR: Parameter index %d out of range.", parm);
+        return true;
+    }
+    return canset(static_cast<EffectIndex>(effect),
+                  static_cast<ParmIndex>(parm));
+}
+
 /*
  * process MIDI controller events
  */
@@ -970,340 +999,424 @@ RKR::process_midi_controller_events(int parameter, int value)
     case 7:
         Master_Volume =
                 (float) value / 128.0f;
+        preserve_parm(FX_Main, Parm_Volume);
         calculavol(2);
         break;
 
     case 1:
-        efx_WhaWha->changepar(6, value);
+        efx_WhaWha->changepar(Parm_Depth, value);
+        preserve_parm(FX_WahWah, Parm_Depth);
         break;
 
     case 20:
-        efx_Alienwah->changepar(6, value);
+        efx_Alienwah->changepar(Parm_Depth, value);
+        preserve_parm(FX_Alienwah, Parm_Depth);
         break;
 
     case 21:
-        efx_Phaser->changepar(6, value);
+        efx_Phaser->changepar(Parm_Depth, value);
+        preserve_parm(FX_Phaser, Parm_Depth);
         break;
 
     case 22:
-        efx_Flanger->changepar(6, value);
+        efx_Flanger->changepar(Parm_Depth, value);
+        preserve_parm(FX_Flanger, Parm_Depth);
         break;
 
     case 23:
-        efx_Chorus->changepar(6, value);
+        efx_Chorus->changepar(Parm_Depth, value);
+        preserve_parm(FX_Chorus, Parm_Depth);
         break;
 
     case 24:
-        efx_MusDelay->changepar(11, value);
+        efx_MusDelay->changepar(Parm_Gain1, value);
+        preserve_parm(FX_MusDelay, Parm_Gain1);
         break;
 
     case 25:
-        efx_MusDelay->changepar(12, value);
+        efx_MusDelay->changepar(Parm_Gain2, value);
+        preserve_parm(FX_MusDelay, Parm_Gain2);
         break;
 
     case 26:
-        efx_Har->changepar(4, ret_LPF(value));
+        efx_Har->changepar(Parm_Freq, ret_LPF(value));
+        preserve_parm(FX_Harmonizer, Parm_Freq);
         break;
 
     case 27:
         if (Harmonizer_Bypass)
         {
             Harmonizer_Bypass = 0;
-            efx_Har->changepar(3, (int) ((float) value * C_MC_24_RANGE));
+            efx_Har->changepar(Parm_Interval,
+                               (int) ((float) value * C_MC_24_RANGE));
+            preserve_parm(FX_Harmonizer, Parm_Interval);
             Harmonizer_Bypass = 1;
         }
         break;
 
     case 28:
-        efx_WhaWha->changepar(0, Dry_Wet(value));
+        efx_WhaWha->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_WahWah, Parm_DryWet);
         break;
 
     case 29:
-        efx_Overdrive->changepar(0, Dry_Wet(value));
+        efx_Overdrive->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Overdrive, Parm_DryWet);
         break;
 
     case 30:
-        efx_Distorsion->changepar(0, Dry_Wet(value));
+        efx_Distorsion->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Distortion, Parm_DryWet);
         break;
 
     case 31:
-        efx_Har->changepar(0, Dry_Wet(value));
+        efx_Har->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Harmonizer, Parm_DryWet);
         break;
 
     case 52:
-        efx_Chorus->changepar(0, Dry_Wet(value));
+        efx_Chorus->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Chorus, Parm_DryWet);
         break;
 
     case 53:
-        efx_Flanger->changepar(0, Dry_Wet(value));
+        efx_Flanger->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Flanger, Parm_DryWet);
         break;
 
     case 54:
-        efx_Phaser->changepar(0, Dry_Wet(value));
+        efx_Phaser->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Phaser, Parm_DryWet);
         break;
 
     case 55:
-        efx_Alienwah->changepar(0, Dry_Wet(value));
+        efx_Alienwah->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Alienwah, Parm_DryWet);
         break;
 
     case 56:
-        efx_MusDelay->changepar(0, Dry_Wet(value));
+        efx_MusDelay->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_MusDelay, Parm_DryWet);
         break;
 
     case 57:
-        efx_Rev->changepar(0, Dry_Wet(value));
+        efx_Rev->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Reverb, Parm_DryWet);
         break;
 
     case 58:
-        efx_Pan->changepar(0, Dry_Wet(value));
+        efx_Pan->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Pan, Parm_DryWet);
         break;
 
     case 59:
-        efx_Echo->changepar(0, Dry_Wet(value));
+        efx_Echo->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Echo, Parm_DryWet);
         break;
 
     case 46:
-        efx_Echo->changepar(1, value);
+        efx_Echo->changepar(Parm_Pan, value);
+        preserve_parm(FX_Echo, Parm_Pan);
         break;
 
     case 47:
-        efx_Overdrive->changepar(1, value);
+        efx_Overdrive->changepar(Parm_Pan, value);
+        preserve_parm(FX_Overdrive, Parm_Pan);
         break;
 
     case 48:
-        efx_Distorsion->changepar(1, value);
+        efx_Distorsion->changepar(Parm_Pan, value);
+        preserve_parm(FX_Distortion, Parm_Pan);
         break;
 
     case 49:
-        efx_Har->changepar(1, value);
+        efx_Har->changepar(Parm_Pan, value);
+        preserve_parm(FX_Harmonizer, Parm_Pan);
         break;
 
     case 50:
-        efx_Chorus->changepar(1, value);
+        efx_Chorus->changepar(Parm_Pan, value);
+        preserve_parm(FX_Chorus, Parm_Pan);
         break;
 
     case 51:
-        efx_Flanger->changepar(1, value);
+        efx_Flanger->changepar(Parm_Pan, value);
+        preserve_parm(FX_Flanger, Parm_Pan);
         break;
 
     case 60:
-        efx_Phaser->changepar(1, value);
+        efx_Phaser->changepar(Parm_Pan, value);
+        preserve_parm(FX_Phaser, Parm_Pan);
         break;
 
     case 61:
-        efx_Alienwah->changepar(1, value);
+        efx_Alienwah->changepar(Parm_Pan, value);
+        preserve_parm(FX_Alienwah, Parm_Pan);
         break;
 
     case 62:
-        efx_MusDelay->changepar(1, value);
+        efx_MusDelay->changepar(Parm_Pan, value);
+        preserve_parm(FX_MusDelay, Parm_Pan);
         break;
 
     case 63:
-        efx_Rev->changepar(1, value);
+        efx_Rev->changepar(Parm_Pan, value);
+        preserve_parm(FX_Reverb, Parm_Pan);
         break;
 
     case 65:
-        efx_MusDelay->changepar(7, value);
+        efx_MusDelay->changepar(Parm_Pan2, value);
+        preserve_parm(FX_MusDelay, Parm_Pan2);
         break;
 
     case 66:
-        efx_WhaWha->changepar(1, value);
+        efx_WhaWha->changepar(Parm_Pan, value);
+        preserve_parm(FX_WahWah, Parm_Pan);
         break;
 
     case 67:
-        efx_Pan->changepar(1, value);
+        efx_Pan->changepar(Parm_Pan, value);
+        preserve_parm(FX_Pan, Parm_Pan);
         break;
 
     case 68:
-        efx_Overdrive->changepar(3, value);
+        efx_Overdrive->changepar(Parm_Drive, value);
+        preserve_parm(FX_Overdrive, Parm_Drive);
         break;
 
     case 69:
-        efx_Distorsion->changepar(3, value);
+        efx_Distorsion->changepar(Parm_Drive, value);
+        preserve_parm(FX_Distortion, Parm_Drive);
         break;
 
     case 70:
-        efx_Overdrive->changepar(4, value);
+        efx_Overdrive->changepar(Parm_Level, value);
+        preserve_parm(FX_Overdrive, Parm_Level);
         break;
 
     case 71:
-        efx_Distorsion->changepar(4, value);
+        efx_Distorsion->changepar(Parm_Level, value);
+        preserve_parm(FX_Distortion, Parm_Level);
         break;
 
     case 72:
-        efx_Chorus->changepar(2, ret_Tempo(value));
+        efx_Chorus->changepar(Parm_LFOFreq, ret_Tempo(value));
+        preserve_parm(FX_Chorus, Parm_LFOFreq);
         break;
 
     case 73:
-        efx_Flanger->changepar(2, ret_Tempo(value));
+        efx_Flanger->changepar(Parm_LFOFreq, ret_Tempo(value));
+        preserve_parm(FX_Flanger, Parm_LFOFreq);
         break;
 
     case 74:
-        efx_Phaser->changepar(2, ret_Tempo(value));
+        efx_Phaser->changepar(Parm_LFOFreq, ret_Tempo(value));
+        preserve_parm(FX_Phaser, Parm_LFOFreq);
         break;
 
     case 75:
-        efx_WhaWha->changepar(2, ret_Tempo(value));
+        efx_WhaWha->changepar(Parm_LFOFreq, ret_Tempo(value));
+        preserve_parm(FX_WahWah, Parm_LFOFreq);
         break;
 
     case 76:
-        efx_Alienwah->changepar(2, ret_Tempo(value));
+        efx_Alienwah->changepar(Parm_LFOFreq, ret_Tempo(value));
+        preserve_parm(FX_Alienwah, Parm_LFOFreq);
         break;
 
     case 77:
-        efx_Pan->changepar(2, ret_Tempo(value));
+        efx_Pan->changepar(Parm_LFOFreq, ret_Tempo(value));
+        preserve_parm(FX_Pan, Parm_LFOFreq);
         break;
 
     case 78:
-        efx_Echo->changepar(5, value);
+        efx_Echo->changepar(Parm_Feedback, value);
+        preserve_parm(FX_Echo, Parm_Feedback);
         break;
 
     case 79:
-        efx_Chorus->changepar(8, value);
+        efx_Chorus->changepar(Parm_Chorus_Feedback, value);
+        preserve_parm(FX_Chorus, Parm_Chorus_Feedback);
         break;
 
     case 80:
-        efx_Flanger->changepar(8, value);
+        efx_Flanger->changepar(Parm_Chorus_Feedback, value);
+        preserve_parm(FX_Flanger, Parm_Chorus_Feedback);
         break;
 
     case 81:
-        efx_Phaser->changepar(7, value);
+        efx_Phaser->changepar(Parm_Phaser_Feedback, value);
+        preserve_parm(FX_Phaser, Parm_Phaser_Feedback);
         break;
 
     case 82:
-        efx_Alienwah->changepar(7, value);
+        efx_Alienwah->changepar(Parm_Phaser_Feedback, value);
+        preserve_parm(FX_Alienwah, Parm_Phaser_Feedback);
         break;
 
     case 83:
-        efx_MusDelay->changepar(5, value);
+        efx_MusDelay->changepar(Parm_Feedback, value);
+        preserve_parm(FX_MusDelay, Parm_Feedback);
         break;
 
     case 84:
-        efx_MusDelay->changepar(9, value);
+        efx_MusDelay->changepar(Parm_MusDelay_Feedback2, value);
+        preserve_parm(FX_MusDelay, Parm_MusDelay_Feedback2);
         break;
 
     case 85:
-        efx_Overdrive->changepar(7, ret_LPF(value));
+        efx_Overdrive->changepar(Parm_LowPassFilter, ret_LPF(value));
+        preserve_parm(FX_Overdrive, Parm_LowPassFilter);
         break;
 
     case 86:
-        efx_Distorsion->changepar(7, ret_LPF(value));
+        efx_Distorsion->changepar(Parm_LowPassFilter, ret_LPF(value));
+        preserve_parm(FX_Distortion, Parm_LowPassFilter);
         break;
 
     case 87:
-        efx_Rev->changepar(7, ret_LPF(value));
+        efx_Rev->changepar(Parm_LowPassFilter, ret_LPF(value));
+        preserve_parm(FX_Reverb, Parm_LowPassFilter);
         break;
 
     case 88:
-        efx_Overdrive->changepar(8, ret_HPF(value));
+        efx_Overdrive->changepar(Parm_HighPassFilter, ret_HPF(value));
+        preserve_parm(FX_Overdrive, Parm_HighPassFilter);
         break;
 
     case 89:
-        efx_Distorsion->changepar(8, ret_HPF(value));
+        efx_Distorsion->changepar(Parm_HighPassFilter, ret_HPF(value));
+        preserve_parm(FX_Distortion, Parm_HighPassFilter);
         break;
 
     case 90:
-        efx_Rev->changepar(8, ret_HPF(value));
+        efx_Rev->changepar(Parm_HighPassFilter, ret_HPF(value));
+        preserve_parm(FX_Reverb, Parm_HighPassFilter);
         break;
 
     case 91:
-        efx_Chorus->changepar(9, value);
+        efx_Chorus->changepar(Parm_LRCross, value);
+        preserve_parm(FX_Chorus, Parm_LRCross);
         break;
 
     case 92:
-        efx_Flanger->changepar(9, value);
+        efx_Flanger->changepar(Parm_LRCross, value);
+        preserve_parm(FX_Flanger, Parm_LRCross);
         break;
 
     case 93:
-        efx_Phaser->changepar(9, value);
+        efx_Phaser->changepar(Parm_LRCross, value);
+        preserve_parm(FX_Phaser, Parm_LRCross);
         break;
 
     case 94:
-        efx_Overdrive->changepar(2, value);
+        efx_Overdrive->changepar(Parm_Dist_LRCross, value);
+        preserve_parm(FX_Overdrive, Parm_Dist_LRCross);
         break;
 
     case 95:
-        efx_Distorsion->changepar(2, value);
+        efx_Distorsion->changepar(Parm_Dist_LRCross, value);
+        preserve_parm(FX_Distortion, Parm_Dist_LRCross);
         break;
 
     case 96:
-        efx_Alienwah->changepar(9, value);
+        efx_Alienwah->changepar(Parm_LRCross, value);
+        preserve_parm(FX_Alienwah, Parm_LRCross);
         break;
 
     case 97:
-        efx_Echo->changepar(4, value);
+        efx_Echo->changepar(Parm_Echo_LRCross, value);
+        preserve_parm(FX_Echo, Parm_Echo_LRCross);
         break;
 
     case 98:
-        efx_MusDelay->changepar(4, value);
+        efx_MusDelay->changepar(Parm_Echo_LRCross, value);
+        preserve_parm(FX_MusDelay, Parm_Echo_LRCross);
         break;
 
     case 99:
-        efx_Chorus->changepar(5, value);
+        efx_Chorus->changepar(Parm_LFOStereo, value);
+        preserve_parm(FX_Chorus, Parm_LFOStereo);
         break;
 
     case 100:
-        efx_Flanger->changepar(5, value);
+        efx_Flanger->changepar(Parm_LFOStereo, value);
+        preserve_parm(FX_Flanger, Parm_LFOStereo);
         break;
 
     case 101:
-        efx_Phaser->changepar(5, value);
+        efx_Phaser->changepar(Parm_LFOStereo, value);
+        preserve_parm(FX_Phaser, Parm_LFOStereo);
         break;
 
     case 102:
-        efx_WhaWha->changepar(5, value);
+        efx_WhaWha->changepar(Parm_LFOStereo, value);
+        preserve_parm(FX_WahWah, Parm_LFOStereo);
         break;
 
     case 103:
-        efx_Alienwah->changepar(5, value);
+        efx_Alienwah->changepar(Parm_LFOStereo, value);
+        preserve_parm(FX_Alienwah, Parm_LFOStereo);
         break;
 
     case 104:
-        efx_Pan->changepar(5, value);
+        efx_Pan->changepar(Parm_LFOStereo, value);
+        preserve_parm(FX_Pan, Parm_LFOStereo);
         break;
 
     case 105:
-        efx_Chorus->changepar(3, value);
+        efx_Chorus->changepar(Parm_LFORandomness, value);
+        preserve_parm(FX_Chorus, Parm_LFORandomness);
         break;
 
     case 106:
-        efx_Flanger->changepar(3, value);
+        efx_Flanger->changepar(Parm_LFORandomness, value);
+        preserve_parm(FX_Flanger, Parm_LFORandomness);
         break;
 
     case 107:
-        efx_Phaser->changepar(3, value);
+        efx_Phaser->changepar(Parm_LFORandomness, value);
+        preserve_parm(FX_Phaser, Parm_LFORandomness);
         break;
 
     case 108:
-        efx_WhaWha->changepar(3, value);
+        efx_WhaWha->changepar(Parm_LFORandomness, value);
+        preserve_parm(FX_WahWah, Parm_LFORandomness);
         break;
 
     case 109:
-        efx_Alienwah->changepar(3, value);
+        efx_Alienwah->changepar(Parm_LFORandomness, value);
+        preserve_parm(FX_Alienwah, Parm_LFORandomness);
         break;
 
     case 110:
-        efx_Pan->changepar(3, value);
+        efx_Pan->changepar(Parm_LFORandomness, value);
+        preserve_parm(FX_Pan, Parm_LFORandomness);
         break;
 
     case 111:
-        efx_WhaWha->changepar(7, value);
+        efx_WhaWha->changepar(Parm_AmpSns, value);
+        preserve_parm(FX_WahWah, Parm_AmpSns);
         break;
 
     case 112:
-        efx_WhaWha->changepar(8, value);
+        efx_WhaWha->changepar(Parm_AmpSnsNS, value);
+        preserve_parm(FX_WahWah, Parm_AmpSnsNS);
         break;
 
     case 113:
-        efx_WhaWha->changepar(9, value);
+        efx_WhaWha->changepar(Parm_AmpSnsSmooth, value);
+        preserve_parm(FX_WahWah, Parm_AmpSnsSmooth);
         break;
 
     case 114:
-        efx_Phaser->changepar(11, value);
+        efx_Phaser->changepar(Parm_Phase, value);
+        preserve_parm(FX_Phaser, Parm_Phase);
         break;
 
     case 115:
-        efx_Alienwah->changepar(10, value);
+        efx_Alienwah->changepar(Parm_Alien_Phase, value);
+        preserve_parm(FX_Alienwah, Parm_Alien_Phase);
         break;
 
     case 116:
@@ -1311,1023 +1424,1273 @@ RKR::process_midi_controller_events(int parameter, int value)
         break;
 
     case 117:
-        efx_APhaser->changepar(0, Dry_Wet(value));
+        efx_APhaser->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_APhaser, Parm_DryWet);
         break;
 
     case 118:
-        efx_APhaser->changepar(1, value);
+        efx_APhaser->changepar(Parm_Distortion, value);
+        preserve_parm(FX_APhaser, Parm_Distortion);
         break;
 
     case 119:
-        efx_APhaser->changepar(2, ret_Tempo(value));
+        efx_APhaser->changepar(Parm_LFOFreq, ret_Tempo(value));
+        preserve_parm(FX_APhaser, Parm_LFOFreq);
         break;
 
     case 120:
-        efx_APhaser->changepar(11, value);
+        efx_APhaser->changepar(Parm_APhaser_Depth, value);
+        preserve_parm(FX_APhaser, Parm_APhaser_Depth);
         break;
 
     case 121:
-        efx_APhaser->changepar(6, value);
+        efx_APhaser->changepar(Parm_Width, value);
+        preserve_parm(FX_APhaser, Parm_Width);
         break;
 
     case 122:
-        efx_APhaser->changepar(7, (int) ((float) value * C_MC_128_RANGE));
+        efx_APhaser->changepar(Parm_Phaser_Feedback, 
+                               (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_APhaser, Parm_Phaser_Feedback);
         break;
 
     case 123:
-        efx_APhaser->changepar(9, value);
+        efx_APhaser->changepar(Parm_Offset, value);
+        preserve_parm(FX_APhaser, Parm_Offset);
         break;
 
     case 124:
-        efx_APhaser->changepar(5, value);
+        efx_APhaser->changepar(Parm_LFOStereo, value);
+        preserve_parm(FX_APhaser, Parm_LFOStereo);
         break;
 
     case 125:
-        efx_Derelict->changepar(0, Dry_Wet(value));
+        efx_Derelict->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Derelict, Parm_DryWet);
         break;
 
     case 126:
-        efx_Derelict->changepar(1, value);
+        efx_Derelict->changepar(Parm_Pan, value);
+        preserve_parm(FX_Derelict, Parm_Pan);
         break;
 
     case 127:
-        efx_Derelict->changepar(2, value);
+        efx_Derelict->changepar(Parm_Dist_LRCross, value);
+        preserve_parm(FX_Derelict, Parm_Dist_LRCross);
         break;
 
     case 2:
-        efx_Derelict->changepar(3, value);
+        efx_Derelict->changepar(Parm_Drive, value);
+        preserve_parm(FX_Derelict, Parm_Drive);
         break;
 
     case 3:
-        efx_Derelict->changepar(4, value);
+        efx_Derelict->changepar(Parm_Level, value);
+        preserve_parm(FX_Derelict, Parm_Level);
         break;
 
     case 4:
-        efx_Derelict->changepar(7, ret_LPF(value));
+        efx_Derelict->changepar(Parm_LowPassFilter, ret_LPF(value));
+        preserve_parm(FX_Derelict, Parm_LowPassFilter);
         break;
 
     case 5:
-        efx_Derelict->changepar(8, ret_HPF(value));
+        efx_Derelict->changepar(Parm_HighPassFilter, ret_HPF(value));
+        preserve_parm(FX_Derelict, Parm_HighPassFilter);
         break;
 
     case 6:
-        efx_Derelict->changepar(9, value);
+        efx_Derelict->changepar(Parm_RFreq, value);
+        preserve_parm(FX_Derelict, Parm_RFreq);
         break;
 
     case 8:
-        efx_Derelict->changepar(11, value);
+        efx_Derelict->changepar(Parm_Octave, value);
+        preserve_parm(FX_Derelict, Parm_Octave);
         break;
 
     case 9:
-        efx_Distorsion->changepar(12, value);
+        efx_Distorsion->changepar(Parm_Dist_Octave, value);
+        preserve_parm(FX_Distortion, Parm_Dist_Octave);
         break;
 
     case 12:
         Fraction_Bypass = (float) value / 127.0f;
+        preserve_parm(FX_Main, Parm_FractionBypass);
         break;
 
     case 14:
         Input_Gain = (float) value / 128.0f;
+        preserve_parm(FX_Main, Parm_InputGain);
         calculavol(1);
         break;
 
     case 130:
-        efx_EQ1->changepar(0, value);
+        efx_EQ1->changepar(Parm_Volume, value);
+        preserve_parm(FX_EQ1, Parm_Volume);
         break;
 
     case 131:
-        for (int i = 0; i < 10; i++) efx_EQ1->changepar(i * 5 + 13, value);
+        for (int i = 0; i < 10; i++) {
+            efx_EQ1->changepar(i * 5 + 13, value);
+            preserve_parm(FX_EQ1, i * 5 + 13);
+        }
         break;
 
     case 132:
         efx_EQ1->changepar(12, value);
+        preserve_parm(FX_EQ1, 12);
         break;
 
     case 133:
         efx_EQ1->changepar(5 + 12, value);
+        preserve_parm(FX_EQ1, 5 + 12);
         break;
 
     case 134:
         efx_EQ1->changepar(10 + 12, value);
+        preserve_parm(FX_EQ1, 10 + 12);
         break;
 
     case 135:
         efx_EQ1->changepar(15 + 12, value);
+        preserve_parm(FX_EQ1, 15 + 12);
         break;
 
     case 136:
         efx_EQ1->changepar(20 + 12, value);
+        preserve_parm(FX_EQ1, 20 + 12);
         break;
 
     case 137:
         efx_EQ1->changepar(25 + 12, value);
+        preserve_parm(FX_EQ1, 25 + 12);
         break;
 
     case 138:
         efx_EQ1->changepar(30 + 12, value);
+        preserve_parm(FX_EQ1, 30 + 12);
         break;
 
     case 139:
         efx_EQ1->changepar(35 + 12, value);
+        preserve_parm(FX_EQ1, 35 + 12);
         break;
 
     case 140:
         efx_EQ1->changepar(40 + 12, value);
+        preserve_parm(FX_EQ1, 40 + 12);
         break;
 
     case 141:
         efx_EQ1->changepar(45 + 12, value);
+        preserve_parm(FX_EQ1, 45 + 12);
         break;
 
     case 142:
-        efx_Compressor->changepar(4, 10 + (int) ((float) value * C_MC_240_RANGE));
+        efx_Compressor->changepar(Parm_AttTime, 10 + (int) ((float) value * C_MC_240_RANGE));
+        preserve_parm(FX_Compressor, Parm_AttTime);
         break;
 
     case 143:
-        efx_Compressor->changepar(5, 10 + (int) ((float) value * C_MC_490_RANGE));
+        efx_Compressor->changepar(Parm_RelTime, 10 + (int) ((float) value * C_MC_490_RANGE));
+        preserve_parm(FX_Compressor, Parm_RelTime);
         break;
 
     case 144:
-        efx_Compressor->changepar(2, 2 + (int) ((float) value * C_MC_40_RANGE));
+        efx_Compressor->changepar(Parm_Ratio, 2 + (int) ((float) value * C_MC_40_RANGE));
+        preserve_parm(FX_Compressor, Parm_Ratio);
         break;
 
     case 145:
-        efx_Compressor->changepar(7, (int) ((float) value * C_MC_100_RANGE));
+        efx_Compressor->changepar(Parm_Knee, (int) ((float) value * C_MC_100_RANGE));
+        preserve_parm(FX_Compressor, Parm_Knee);
         break;
 
     case 146:
-        efx_Compressor->changepar(1, -60 + (int) ((float) value * C_MC_57_RANGE));
+        efx_Compressor->changepar(Parm_Threshold, -60 + (int) ((float) value * C_MC_57_RANGE));
+        preserve_parm(FX_Compressor, Parm_Threshold);
         break;
 
     case 147:
-        efx_Compressor->changepar(3, -40 + (int) ((float) value * C_MC_40_RANGE));
+        efx_Compressor->changepar(Parm_Output, -40 + (int) ((float) value * C_MC_40_RANGE));
+        preserve_parm(FX_Compressor, Parm_Output);
         break;
 
     case 148:
-        efx_EQ2->changepar(0, value);
+        efx_EQ2->changepar(Parm_Volume, value);
+        preserve_parm(FX_EQ2, Parm_Volume);
         break;
 
     case 149:
         efx_EQ2->changepar(11, 20 + (int) ((float) value * C_MC_980_RANGE));
+        preserve_parm(FX_EQ2, 11);
         break;
 
     case 150:
         efx_EQ2->changepar(12, value);
+        preserve_parm(FX_EQ2, 12);
         break;
 
     case 151:
         efx_EQ2->changepar(13, value);
+        preserve_parm(FX_EQ2, 13);
         break;
 
     case 152:
         efx_EQ2->changepar(16, 800 + (int) ((float) value * C_MC_7200_RANGE));
+        preserve_parm(FX_EQ2, 16);
         break;
 
     case 153:
         efx_EQ2->changepar(17, value);
+        preserve_parm(FX_EQ2, 17);
         break;
 
     case 154:
         efx_EQ2->changepar(18, value);
+        preserve_parm(FX_EQ2, 18);
         break;
 
     case 155:
         efx_EQ2->changepar(21, 6000 + (int) ((float) value * C_MC_20000_RANGE));
+        preserve_parm(FX_EQ2, 21);
         break;
 
     case 156:
         efx_EQ2->changepar(22, value);
+        preserve_parm(FX_EQ2, 22);
         break;
 
     case 157:
         efx_EQ2->changepar(23, value);
+        preserve_parm(FX_EQ2, 23);
         break;
 
     case 158:
-        efx_DFlange->changepar(0, Dry_Wet(value));
+        efx_DFlange->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_DFlange, Parm_DryWet);
         break;
 
     case 159:
-        efx_DFlange->changepar(1, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_DFlange->changepar(Parm_Pan, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_DFlange, Parm_Pan);
         break;
 
     case 160:
-        efx_DFlange->changepar(2, value);
+        efx_DFlange->changepar(Parm_Dist_LRCross, value);
+        preserve_parm(FX_DFlange, Parm_Dist_LRCross);
         break;
 
     case 161:
-        efx_DFlange->changepar(3, 20 + (int) ((float) value * C_MC_2480_RANGE));
+        efx_DFlange->changepar(Parm_DFlange_Depth, 20 + (int) ((float) value * C_MC_2480_RANGE));
+        preserve_parm(FX_DFlange, Parm_DFlange_Depth);
         break;
 
     case 162:
-        efx_DFlange->changepar(4, (int) ((float) value * C_MC_6000_RANGE));
+        efx_DFlange->changepar(Parm_DFlange_Width, (int) ((float) value * C_MC_6000_RANGE));
+        preserve_parm(FX_DFlange, Parm_DFlange_Width);
         break;
 
     case 163:
-        efx_DFlange->changepar(5, (int) ((float) value * C_MC_100_RANGE));
+        efx_DFlange->changepar(Parm_DFlange_Offset, (int) ((float) value * C_MC_100_RANGE));
+        preserve_parm(FX_DFlange, Parm_DFlange_Offset);
         break;
 
     case 164:
-        efx_DFlange->changepar(6, ((int) (float) value * C_MC_128_RANGE) - 64);
+        efx_DFlange->changepar(Parm_DFlange_Feedback, ((int) (float) value * C_MC_128_RANGE) - 64);
+        preserve_parm(FX_DFlange, Parm_DFlange_Feedback);
         break;
 
     case 165:
         /* This is labeled LPF but uses same range as HPF - FIXME check DSP */
-        efx_DFlange->changepar(7, 20 + (int) ((float) value * C_MC_19980_RANGE));
+        efx_DFlange->changepar(Parm_DFlange_HiDamp, 20 + (int) ((float) value * C_MC_19980_RANGE));
+        preserve_parm(FX_DFlange, Parm_DFlange_HiDamp);
         break;
 
     case 166:
-        efx_DFlange->changepar(10, ret_Tempo(value));
+        efx_DFlange->changepar(Parm_DFlange_LFOFreq, ret_Tempo(value));
+        preserve_parm(FX_DFlange, Parm_DFlange_LFOFreq);
         break;
 
     case 167:
-        efx_DFlange->changepar(11, value);
+        efx_DFlange->changepar(Parm_DFlange_LFOStereo, value);
+        preserve_parm(FX_DFlange, Parm_DFlange_LFOStereo);
         break;
 
     case 168:
-        efx_DFlange->changepar(13, value);
+        efx_DFlange->changepar(Parm_DFlange_LFORandomness, value);
+        preserve_parm(FX_DFlange, Parm_DFlange_LFORandomness);
         break;
 
     case 169:
-        efx_Valve->changepar(0, Dry_Wet(value));
+        efx_Valve->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Valve, Parm_DryWet);
         break;
 
     case 170:
-        efx_Valve->changepar(2, value);
+        efx_Valve->changepar(Parm_Dist_LRCross, value);
+        preserve_parm(FX_Valve, Parm_Dist_LRCross);
         break;
 
     case 171:
-        efx_Valve->changepar(1, value);
+        efx_Valve->changepar(Parm_Pan, value);
+        preserve_parm(FX_Valve, Parm_Pan);
         break;
 
     case 172:
-        efx_Valve->changepar(4, value);
+        efx_Valve->changepar(Parm_Level, value);
+        preserve_parm(FX_Valve, Parm_Level);
         break;
 
     case 173:
-        efx_Valve->changepar(3, value);
+        efx_Valve->changepar(Parm_Drive, value);
+        preserve_parm(FX_Valve, Parm_Drive);
         break;
 
     case 174:
-        efx_Valve->changepar(10, value);
+        efx_Valve->changepar(Parm_Q, value);
+        preserve_parm(FX_Valve, Parm_Q);
         break;
 
     case 175:
-        efx_Valve->changepar(12, (int) ((float) value * C_MC_100_RANGE));
+        efx_Valve->changepar(Parm_Presence, (int) ((float) value * C_MC_100_RANGE));
+        preserve_parm(FX_Valve, Parm_Presence);
         break;
 
     case 176:
-        efx_Valve->changepar(6, ret_LPF(value));
+        efx_Valve->changepar(Parm_Valve_LowPass, ret_LPF(value));
+        preserve_parm(FX_Valve, Parm_Valve_LowPass);
         break;
 
     case 177:
-        efx_Valve->changepar(7, ret_HPF(value));
+        efx_Valve->changepar(Parm_Valve_HighPass, ret_HPF(value));
+        preserve_parm(FX_Valve, Parm_Valve_HighPass);
         break;
 
     case 178:
-        efx_Ring->changepar(0, Dry_Wet(value));
+        efx_Ring->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Ring, Parm_DryWet);
         break;
 
     case 179:
-        efx_Ring->changepar(2, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_Ring->changepar(Parm_Dist_LRCross, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_Ring, Parm_Dist_LRCross);
         break;
 
     case 180:
-        efx_Ring->changepar(11, 1 + (int) ((float) value * C_MC_126_RANGE));
+        efx_Ring->changepar(Parm_Input, 1 + (int) ((float) value * C_MC_126_RANGE));
+        preserve_parm(FX_Ring, Parm_Input);
         break;
 
     case 181:
-        efx_Ring->changepar(3, value);
+        efx_Ring->changepar(Parm_Ring_Level, value);
+        preserve_parm(FX_Ring, Parm_Ring_Level);
         break;
 
     case 182:
-        efx_Ring->changepar(1, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_Ring->changepar(Parm_Pan, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_Ring, Parm_Pan);
         break;
 
     case 183:
-        efx_Ring->changepar(4, (int) ((float) value * C_MC_100_RANGE));
+        efx_Ring->changepar(Parm_Ring_Depth, (int) ((float) value * C_MC_100_RANGE));
+        preserve_parm(FX_Ring, Parm_Ring_Depth);
         break;
 
     case 184:
-        efx_Ring->changepar(5, 1 + (int) ((float) value * C_MC_19999_RANGE));
+        efx_Ring->changepar(Parm_Ring_Freq, 1 + (int) ((float) value * C_MC_19999_RANGE));
+        preserve_parm(FX_Ring, Parm_Ring_Freq);
         break;
 
     case 185:
-        efx_Ring->changepar(7, (int) ((float) value * C_MC_100_RANGE));
+        efx_Ring->changepar(Parm_Ring_Sine, (int) ((float) value * C_MC_100_RANGE));
+        preserve_parm(FX_Ring, Parm_Ring_Sine);
         break;
 
     case 186:
-        efx_Ring->changepar(8, (int) ((float) value * C_MC_100_RANGE));
+        efx_Ring->changepar(Parm_Ring_Tri, (int) ((float) value * C_MC_100_RANGE));
+        preserve_parm(FX_Ring, Parm_Ring_Tri);
         break;
 
     case 187:
-        efx_Ring->changepar(9, (int) ((float) value * C_MC_100_RANGE));
+        efx_Ring->changepar(Parm_Ring_Saw, (int) ((float) value * C_MC_100_RANGE));
+        preserve_parm(FX_Ring, Parm_Ring_Saw);
         break;
 
     case 188:
-        efx_Ring->changepar(10, (int) ((float) value * C_MC_100_RANGE));
+        efx_Ring->changepar(Parm_Ring_Square, (int) ((float) value * C_MC_100_RANGE));
+        preserve_parm(FX_Ring, Parm_Ring_Square);
         break;
 
     case 189:
-        efx_Exciter->changepar(0, value);
+        efx_Exciter->changepar(Parm_Volume, value);
+        preserve_parm(FX_Exciter, Parm_Volume);
         break;
 
     case 190:
-        efx_Exciter->changepar(11, ret_HPF(value));
+        efx_Exciter->changepar(Parm_Exciter_LowPassFilter, ret_LPF(value));
+        preserve_parm(FX_Exciter, Parm_Exciter_LowPassFilter);
         break;
 
     case 191:
-        efx_Exciter->changepar(12, ret_LPF(value));
+        efx_Exciter->changepar(Parm_Exciter_HighPassFilter, ret_HPF(value));
+        preserve_parm(FX_Exciter, Parm_Exciter_HighPassFilter);
         break;
 
     case 192:
-        efx_Exciter->changepar(1, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_Exciter->changepar(Parm_Exciter_H1, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_Exciter, Parm_Exciter_H1);
         break;
 
     case 193:
-        efx_Exciter->changepar(2, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_Exciter->changepar(Parm_Exciter_H2, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_Exciter, Parm_Exciter_H2);
         break;
 
     case 194:
-        efx_Exciter->changepar(3, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_Exciter->changepar(Parm_Exciter_H3, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_Exciter, Parm_Exciter_H3);
         break;
 
     case 195:
-        efx_Exciter->changepar(4, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_Exciter->changepar(Parm_Exciter_H4, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_Exciter, Parm_Exciter_H4);
         break;
 
     case 196:
-        efx_Exciter->changepar(5, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_Exciter->changepar(Parm_Exciter_H5, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_Exciter, Parm_Exciter_H5);
         break;
 
     case 197:
-        efx_Exciter->changepar(6, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_Exciter->changepar(Parm_Exciter_H6, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_Exciter, Parm_Exciter_H6);
         break;
 
     case 198:
-        efx_Exciter->changepar(7, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_Exciter->changepar(Parm_Exciter_H7, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_Exciter, Parm_Exciter_H7);
         break;
 
     case 199:
-        efx_Exciter->changepar(8, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_Exciter->changepar(Parm_Exciter_H8, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_Exciter, Parm_Exciter_H8);
         break;
 
     case 200:
-        efx_Exciter->changepar(9, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_Exciter->changepar(Parm_Exciter_H9, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_Exciter, Parm_Exciter_H9);
         break;
 
     case 201:
-        efx_Exciter->changepar(10, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_Exciter->changepar(Parm_Exciter_H10, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_Exciter, Parm_Exciter_H10);
         break;
 
     case 202:
-        efx_DistBand->changepar(0, Dry_Wet(value));
+        efx_DistBand->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_DistBand, Parm_DryWet);
         break;
 
     case 203:
-        efx_DistBand->changepar(2, value);
+        efx_DistBand->changepar(Parm_Dist_LRCross, value);
+        preserve_parm(FX_DistBand, Parm_Dist_LRCross);
         break;
 
     case 204:
-        efx_DistBand->changepar(3, value);
+        efx_DistBand->changepar(Parm_Drive, value);
+        preserve_parm(FX_DistBand, Parm_Drive);
         break;
 
     case 205:
-        efx_DistBand->changepar(4, value);
+        efx_DistBand->changepar(Parm_Level, value);
+        preserve_parm(FX_DistBand, Parm_Level);
         break;
 
     case 206:
-        efx_DistBand->changepar(8, (int) ((float) value * C_MC_100_RANGE));
+        efx_DistBand->changepar(Parm_DistBand_LowVol, (int) ((float) value * C_MC_100_RANGE));
+        preserve_parm(FX_DistBand, Parm_DistBand_LowVol);
         break;
 
     case 207:
-        efx_DistBand->changepar(9, (int) ((float) value * C_MC_100_RANGE));
+        efx_DistBand->changepar(Parm_DistBand_MidVol, (int) ((float) value * C_MC_100_RANGE));
+        preserve_parm(FX_DistBand, Parm_DistBand_MidVol);
         break;
 
     case 208:
-        efx_DistBand->changepar(10, (int) ((float) value * C_MC_100_RANGE));
+        efx_DistBand->changepar(Parm_DistBand_HighVol, (int) ((float) value * C_MC_100_RANGE));
+        preserve_parm(FX_DistBand, Parm_DistBand_HighVol);
         break;
 
     case 209:
-        efx_DistBand->changepar(12, 20 + (int) ((float) value * C_MC_980_RANGE));
+        efx_DistBand->changepar(Parm_DistBand_Cross1, 20 + (int) ((float) value * C_MC_980_RANGE));
+        preserve_parm(FX_DistBand, Parm_DistBand_Cross1);
         break;
 
     case 210:
-        efx_DistBand->changepar(13, 800 + (int) ((float) value * C_MC_11200_RANGE));
+        efx_DistBand->changepar(Parm_DistBand_Cross2, 800 + (int) ((float) value * C_MC_11200_RANGE));
+        preserve_parm(FX_DistBand, Parm_DistBand_Cross2);
         break;
 
     case 211:
-        efx_DistBand->changepar(1, value);
+        efx_DistBand->changepar(Parm_Pan, value);
+        preserve_parm(FX_DistBand, Parm_Pan);
         break;
 
     case 212:
-        efx_Arpie->changepar(0, Dry_Wet(value));
+        efx_Arpie->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Arpie, Parm_DryWet);
         break;
 
     case 213:
-        efx_Arpie->changepar(7, value);
+        efx_Arpie->changepar(Parm_Arpie_Reverse, value);
+        preserve_parm(FX_Arpie, Parm_Arpie_Reverse);
         break;
 
     case 214:
-        efx_Arpie->changepar(1, value - 64);
+        efx_Arpie->changepar(Parm_Pan, value - 64);
+        preserve_parm(FX_Arpie, Parm_Pan);
         break;
 
     case 215:
-        efx_Arpie->changepar(2, ret_Tempo(value));
+        efx_Arpie->changepar(Parm_Arpie_Tempo, ret_Tempo(value));
+        preserve_parm(FX_Arpie, Parm_Arpie_Tempo);
         break;
 
     case 216:
-        efx_Arpie->changepar(3, value);
+        efx_Arpie->changepar(Parm_Arpie_LRDelay, value);
+        preserve_parm(FX_Arpie, Parm_Arpie_LRDelay);
         break;
 
     case 217:
-        efx_Arpie->changepar(4, value);
+        efx_Arpie->changepar(Parm_Echo_LRCross, value);
+        preserve_parm(FX_Arpie, Parm_Echo_LRCross);
         break;
 
     case 218:
-        efx_Arpie->changepar(5, value);
+        efx_Arpie->changepar(Parm_Feedback, value);
+        preserve_parm(FX_Arpie, Parm_Feedback);
         break;
 
     case 219:
-        efx_Arpie->changepar(6, value);
+        efx_Arpie->changepar(Parm_Arpie_HiDamp, value);
+        preserve_parm(FX_Arpie, Parm_Arpie_HiDamp);
         break;
 
     case 220:
-        efx_Expander->changepar(3, 1 + (int) ((float) value * C_MC_4999_RANGE));
+        efx_Expander->changepar(Parm_Expander_Attack, 1 + (int) ((float) value * C_MC_4999_RANGE));
+        preserve_parm(FX_Expander, Parm_Expander_Attack);
         break;
 
     case 221:
-        efx_Expander->changepar(4, 10 + (int) ((float) value * C_MC_990_RANGE));
+        efx_Expander->changepar(Parm_Expander_Decay, 10 + (int) ((float) value * C_MC_990_RANGE));
+        preserve_parm(FX_Expander, Parm_Expander_Decay);
         break;
 
     case 222:
-        efx_Expander->changepar(2, 1 + (int) ((float) value * C_MC_49_RANGE));
+        efx_Expander->changepar(Parm_Expander_Shape, 1 + (int) ((float) value * C_MC_49_RANGE));
+        preserve_parm(FX_Expander, Parm_Expander_Shape);
         break;
 
     case 223:
-        efx_Expander->changepar(1, (int) ((float) value * -C_MC_80_RANGE));
+        efx_Expander->changepar(Parm_Expander_Threshold, (int) ((float) value * -C_MC_80_RANGE));
+        preserve_parm(FX_Expander, Parm_Expander_Threshold);
         break;
 
     case 224:
-        efx_Expander->changepar(7, 1 + (int) ((float) value * C_MC_126_RANGE));
+        efx_Expander->changepar(Parm_Expander_OutGain, 1 + (int) ((float) value * C_MC_126_RANGE));
+        preserve_parm(FX_Expander, Parm_Expander_OutGain);
         break;
 
     case 225:
-        efx_Expander->changepar(5, ret_LPF(value));
+        efx_Expander->changepar(Parm_Expander_LowPassFilter, ret_LPF(value));
+        preserve_parm(FX_Expander, Parm_Expander_LowPassFilter);
         break;
 
     case 226:
-        efx_Expander->changepar(6, ret_HPF(value));
+        efx_Expander->changepar(Parm_Expander_HighPassFilter, ret_HPF(value));
+        preserve_parm(FX_Expander, Parm_Expander_HighPassFilter);
         break;
 
     case 227:
-        efx_Shuffle->changepar(0, Dry_Wet(value));
+        efx_Shuffle->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Shuffle, Parm_DryWet);
         break;
 
     case 228:
-        efx_Shuffle->changepar(5, 20 + (int) ((float) value * C_MC_980_RANGE));
+        efx_Shuffle->changepar(Parm_Shuffle_Cross1, 20 + (int) ((float) value * C_MC_980_RANGE));
+        preserve_parm(FX_Shuffle, Parm_Shuffle_Cross1);
         break;
 
     case 229:
-        efx_Shuffle->changepar(1, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_Shuffle->changepar(Parm_Shuffle_GainLow, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_Shuffle, Parm_Shuffle_GainLow);
         break;
 
     case 230:
-        efx_Shuffle->changepar(6, 400 + (int) ((float) value * C_MC_3600_RANGE));
+        efx_Shuffle->changepar(Parm_Shuffle_Cross2, 400 + (int) ((float) value * C_MC_3600_RANGE));
+        preserve_parm(FX_Shuffle, Parm_Shuffle_Cross2);
         break;
 
     case 231:
-        efx_Shuffle->changepar(2, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_Shuffle->changepar(Parm_Shuffle_GainMidLow, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_Shuffle, Parm_Shuffle_GainMidLow);
         break;
 
     case 232:
-        efx_Shuffle->changepar(7, 1200 + (int) ((float) value * C_MC_6800_RANGE));
+        efx_Shuffle->changepar(Parm_Shuffle_Cross3, 1200 + (int) ((float) value * C_MC_6800_RANGE));
+        preserve_parm(FX_Shuffle, Parm_Shuffle_Cross3);
         break;
 
     case 233:
-        efx_Shuffle->changepar(3, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_Shuffle->changepar(Parm_Shuffle_GainMidHigh, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_Shuffle, Parm_Shuffle_GainMidHigh);
         break;
 
     case 234:
-        efx_Shuffle->changepar(8, 6000 + (int) ((float) value * C_MC_20000_RANGE));
+        efx_Shuffle->changepar(Parm_Shuffle_Cross4, 6000 + (int) ((float) value * C_MC_20000_RANGE));
+        preserve_parm(FX_Shuffle, Parm_Shuffle_Cross4);
         break;
 
     case 235:
-        efx_Shuffle->changepar(4, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_Shuffle->changepar(Parm_Shuffle_GainHigh, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_Shuffle, Parm_Shuffle_GainHigh);
         break;
 
     case 236:
-        efx_Shuffle->changepar(9, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_Shuffle->changepar(Parm_Shuffle_Q, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_Shuffle, Parm_Shuffle_Q);
         break;
 
     case 237:
-        efx_Synthfilter->changepar(0, Dry_Wet(value));
+        efx_Synthfilter->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Synthfilter, Parm_DryWet);
         break;
 
     case 238:
-        efx_Synthfilter->changepar(1, value);
+        efx_Synthfilter->changepar(Parm_Distortion, value);
+        preserve_parm(FX_Synthfilter, Parm_Distortion);
         break;
 
     case 239:
-        efx_Synthfilter->changepar(2, ret_Tempo(value));
+        efx_Synthfilter->changepar(Parm_LFOFreq, ret_Tempo(value));
+        preserve_parm(FX_Synthfilter, Parm_LFOFreq);
         break;
 
     case 240:
-        efx_Synthfilter->changepar(5, value);
+        efx_Synthfilter->changepar(Parm_LFOStereo, value);
+        preserve_parm(FX_Synthfilter, Parm_LFOStereo);
         break;
 
     case 241:
-        efx_Synthfilter->changepar(6, value);
+        efx_Synthfilter->changepar(Parm_Width, value);
+        preserve_parm(FX_Synthfilter, Parm_Width);
         break;
 
     case 242:
-        efx_Synthfilter->changepar(7, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_Synthfilter->changepar(Parm_Phaser_Feedback, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_Synthfilter, Parm_Phaser_Feedback);
         break;
 
     case 243:
-        efx_Synthfilter->changepar(11, value);
+        efx_Synthfilter->changepar(Parm_APhaser_Depth, value);
+        preserve_parm(FX_Synthfilter, Parm_APhaser_Depth);
         break;
 
     case 244:
-        efx_Synthfilter->changepar(12, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_Synthfilter->changepar(Parm_Synthfilter_Envelope, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_Synthfilter, Parm_Synthfilter_Envelope);
         break;
 
     case 245:
-        efx_Synthfilter->changepar(13, 5 + (int) ((float) value * C_MC_995_RANGE));
+        efx_Synthfilter->changepar(Parm_Synthfilter_Attack, 5 + (int) ((float) value * C_MC_995_RANGE));
+        preserve_parm(FX_Synthfilter, Parm_Synthfilter_Attack);
         break;
 
     case 246:
-        efx_Synthfilter->changepar(14, 5 + (int) ((float) value * C_MC_495_RANGE));
+        efx_Synthfilter->changepar(Parm_Synthfilter_Release, 5 + (int) ((float) value * C_MC_495_RANGE));
+        preserve_parm(FX_Synthfilter, Parm_Synthfilter_Release);
         break;
 
     case 247:
-        efx_Synthfilter->changepar(15, value);
+        efx_Synthfilter->changepar(Parm_Synthfilter_Bandwidth, value);
+        preserve_parm(FX_Synthfilter, Parm_Synthfilter_Bandwidth);
         break;
 
     case 248:
-        efx_VaryBand->changepar(0, Dry_Wet(value));
+        efx_VaryBand->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_VaryBand, Parm_DryWet);
         break;
 
     case 249:
-        efx_VaryBand->changepar(1, ret_Tempo(value));
+        efx_VaryBand->changepar(Parm_VaryBand_LFOFreq, ret_Tempo(value));
+        preserve_parm(FX_VaryBand, Parm_VaryBand_LFOFreq);
         break;
 
     case 250:
-        efx_VaryBand->changepar(3, value);
+        efx_VaryBand->changepar(Parm_VaryBand_LFOStereo, value);
+        preserve_parm(FX_VaryBand, Parm_VaryBand_LFOStereo);
         break;
 
     case 251:
-        efx_VaryBand->changepar(4, ret_Tempo(value));
+        efx_VaryBand->changepar(Parm_VaryBand_LFO2Freq, ret_Tempo(value));
+        preserve_parm(FX_VaryBand, Parm_VaryBand_LFO2Freq);
         break;
 
     case 252:
-        efx_VaryBand->changepar(6, value);
+        efx_VaryBand->changepar(Parm_VaryBand_LFO2Stereo, value);
+        preserve_parm(FX_VaryBand, Parm_VaryBand_LFO2Stereo);
         break;
 
     case 253:
-        efx_VaryBand->changepar(7, 20 + (int) ((float) value * C_MC_980_RANGE));
+        efx_VaryBand->changepar(Parm_VaryBand_Cross1, 20 + (int) ((float) value * C_MC_980_RANGE));
+        preserve_parm(FX_VaryBand, Parm_VaryBand_Cross1);
         break;
 
     case 254:
-        efx_VaryBand->changepar(8, 1000 + (int) ((float) value * C_MC_7000_RANGE));
+        efx_VaryBand->changepar(Parm_VaryBand_Cross2, 1000 + (int) ((float) value * C_MC_7000_RANGE));
+        preserve_parm(FX_VaryBand, Parm_VaryBand_Cross2);
         break;
 
     case 255:
-        efx_VaryBand->changepar(9, 2000 + (int) ((float) value * C_MC_24000_RANGE));
+        efx_VaryBand->changepar(Parm_VaryBand_Cross3, 2000 + (int) ((float) value * C_MC_24000_RANGE));
+        preserve_parm(FX_VaryBand, Parm_VaryBand_Cross3);
         break;
 
     case 256:
-        efx_MuTroMojo->changepar(0, Dry_Wet(value));
+        efx_MuTroMojo->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_MuTroMojo, Parm_DryWet);
         break;
 
     case 257:
-        efx_MuTroMojo->changepar(10, value - 64);
+        efx_MuTroMojo->changepar(Parm_MuTroMojo_LowPassLvl, value - 64);
+        preserve_parm(FX_MuTroMojo, Parm_MuTroMojo_LowPassLvl);
         break;
 
     case 258:
-        efx_MuTroMojo->changepar(11, value - 64);
+        efx_MuTroMojo->changepar(Parm_MuTroMojo_BandPassLvl, value - 64);
+        preserve_parm(FX_MuTroMojo, Parm_MuTroMojo_BandPassLvl);
         break;
 
     case 259:
-        efx_MuTroMojo->changepar(12, value - 64);
+        efx_MuTroMojo->changepar(Parm_MuTroMojo_HighPassLvl, value - 64);
+        preserve_parm(FX_MuTroMojo, Parm_MuTroMojo_HighPassLvl);
         break;
 
     case 260:
-        efx_MuTroMojo->changepar(6, value);
+        efx_MuTroMojo->changepar(Parm_Depth, value);
+        preserve_parm(FX_MuTroMojo, Parm_Depth);
         break;
 
     case 261:
-        efx_MuTroMojo->changepar(2, ret_Tempo(value));
+        efx_MuTroMojo->changepar(Parm_LFOFreq, ret_Tempo(value));
+        preserve_parm(FX_MuTroMojo, Parm_LFOFreq);
         break;
 
     case 262:
-        efx_MuTroMojo->changepar(1, value);
+        efx_MuTroMojo->changepar(Parm_MuTroMojo_Q, value);
+        preserve_parm(FX_MuTroMojo, Parm_MuTroMojo_Q);
         break;
 
     case 263:
-        efx_MuTroMojo->changepar(14, 10 + (int) ((float) value * C_MC_5990_RANGE));
+        efx_MuTroMojo->changepar(Parm_Range, 10 + (int) ((float) value * C_MC_5990_RANGE));
+        preserve_parm(FX_MuTroMojo, Parm_Range);
         break;
 
     case 264:
-        efx_MuTroMojo->changepar(8, value);
+        efx_MuTroMojo->changepar(Parm_MuTroMojo_AmpSnsInv, value);
+        preserve_parm(FX_MuTroMojo, Parm_MuTroMojo_AmpSnsInv);
         break;
 
     case 265:
-        efx_MuTroMojo->changepar(7, value - 64);
+        efx_MuTroMojo->changepar(Parm_MuTroMojo_AmpSns, value - 64);
+        preserve_parm(FX_MuTroMojo, Parm_MuTroMojo_AmpSns);
         break;
 
     case 266:
-        efx_MuTroMojo->changepar(9, value);
+        efx_MuTroMojo->changepar(Parm_MuTroMojo_AmpSmooth, value);
+        preserve_parm(FX_MuTroMojo, Parm_MuTroMojo_AmpSmooth);
         break;
 
     case 267:
-        efx_Looper->changepar(0, Dry_Wet(value));
+        efx_Looper->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Looper, Parm_DryWet);
         break;
 
     case 268:
-        efx_Looper->changepar(6, value);
+        efx_Looper->changepar(Parm_Looper_Fade1, value);
+        preserve_parm(FX_Looper, Parm_Looper_Fade1);
         break;
 
     case 269:
-        efx_Looper->changepar(10, value);
+        efx_Looper->changepar(Parm_Looper_Fade2, value);
+        preserve_parm(FX_Looper, Parm_Looper_Fade2);
         break;
 
     case 270:
     {
         int i = 0;
         if (value) i = 1;
-        efx_Looper->changepar(5, i);
+        efx_Looper->changepar(Parm_Looper_Reverse, i);
+        preserve_parm(FX_Looper, Parm_Looper_Reverse);
         break;
     }
     case 271:
     {
         int i = 0;
         if (value) i = 1;
-        efx_Looper->changepar(9, i);
+        efx_Looper->changepar(Parm_Looper_Autoplay, i);
+        preserve_parm(FX_Looper, Parm_Looper_Autoplay);
         break;
     }
     case 272:
     {
         int i = 0;
         if (value) i = 1;
-        efx_Looper->changepar(1, i);
+        efx_Looper->changepar(Parm_Looper_Play, i);
+        preserve_parm(FX_Looper, Parm_Looper_Play);
         break;
     }
     case 273:
     {
         int i = 0;
         if (value) i = 1;
-        efx_Looper->changepar(2, i);
+        efx_Looper->changepar(Parm_Looper_Stop, i);
+        preserve_parm(FX_Looper, Parm_Looper_Stop);
         break;
     }
     case 274:
     {
         int i = 0;
         if (value) i = 1;
-        efx_Looper->changepar(3, i);
+        efx_Looper->changepar(Parm_Looper_Record, i);
+        preserve_parm(FX_Looper, Parm_Looper_Record);
         break;
     }
     case 275:
     {
         int i = 0;
         if (value) i = 1;
-        efx_Looper->changepar(11, i);
+        efx_Looper->changepar(Parm_Looper_Record1, i);
+        preserve_parm(FX_Looper, Parm_Looper_Record1);
         break;
     }
     case 276:
     {
         int i = 0;
         if (value) i = 1;
-        efx_Looper->changepar(12, i);
+        efx_Looper->changepar(Parm_Looper_Record2, i);
+        preserve_parm(FX_Looper, Parm_Looper_Record2);
         break;
     }
     case 277:
     {
         int i = 0;
         if (value) i = 1;
-        efx_Looper->changepar(7, i);
+        efx_Looper->changepar(Parm_Looper_Track1, i);
+        preserve_parm(FX_Looper, Parm_Looper_Track1);
         break;
     }
     case 278:
     {
         int i = 0;
         if (value) i = 1;
-        efx_Looper->changepar(8, i);
+        efx_Looper->changepar(Parm_Looper_Track2, i);
+        preserve_parm(FX_Looper, Parm_Looper_Track2);
         break;
     }
     case 279:
     {
         int i = 0;
         if (value) i = 1;
-        efx_Looper->changepar(4, i);
+        efx_Looper->changepar(Parm_Looper_Clear, i);
+        preserve_parm(FX_Looper, Parm_Looper_Clear);
         break;
     }
     case 280:
-        efx_Convol->changepar(0, Dry_Wet(value));
+        efx_Convol->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Convolotron, Parm_DryWet);
         break;
 
     case 281:
-        efx_Convol->changepar(1, value);
+        efx_Convol->changepar(Parm_Pan, value);
+        preserve_parm(FX_Convolotron, Parm_Pan);
         break;
 
     case 282:
-        efx_Convol->changepar(7, value);
+        efx_Convol->changepar(Parm_Convolotron_Level, value);
+        preserve_parm(FX_Convolotron, Parm_Convolotron_Level);
         break;
 
     case 283:
-        efx_Convol->changepar(6, value);
+        efx_Convol->changepar(Parm_Arpie_HiDamp, value);
+        preserve_parm(FX_Convolotron, Parm_Arpie_HiDamp);
         break;
 
     case 284:
-        efx_Convol->changepar(10, ((int) (float) value * C_MC_128_RANGE) - 64);
+        efx_Convol->changepar(Parm_Convolotron_Feedback, ((int) (float) value * C_MC_128_RANGE) - 64);
+        preserve_parm(FX_Convolotron, Parm_Convolotron_Feedback);
         break;
 
     case 285:
-        efx_Convol->changepar(3, 5 + (int) ((float) value * C_MC_245_RANGE));
+        efx_Convol->changepar(Parm_Convolotron_Length, 5 + (int) ((float) value * C_MC_245_RANGE));
+        preserve_parm(FX_Convolotron, Parm_Convolotron_Length);
         break;
 
     case 286:
-        efx_CoilCrafter->changepar(0, value);
+        efx_CoilCrafter->changepar(Parm_Volume, value);
+        preserve_parm(FX_CoilCrafter, Parm_Volume);
         break;
 
     case 287:
-        efx_CoilCrafter->changepar(7, 20 + (int) ((float) value * C_MC_4380_RANGE));
+        efx_CoilCrafter->changepar(Parm_CoilCrafter_HighPassFilter, 20 + (int) ((float) value * C_MC_4380_RANGE));
+        preserve_parm(FX_CoilCrafter, Parm_CoilCrafter_HighPassFilter);
         break;
 
     case 288:
-        efx_CoilCrafter->changepar(3, 2600 + (int) ((float) value * C_MC_1900_RANGE));
+        efx_CoilCrafter->changepar(Parm_CoilCrafter_Freq1, 2600 + (int) ((float) value * C_MC_1900_RANGE));
+        preserve_parm(FX_CoilCrafter, Parm_CoilCrafter_Freq1);
         break;
 
     case 289:
-        efx_CoilCrafter->changepar(4, 10 + (int) ((float) value * C_MC_55_RANGE));
+        efx_CoilCrafter->changepar(Parm_CoilCrafter_Q1, 10 + (int) ((float) value * C_MC_55_RANGE));
+        preserve_parm(FX_CoilCrafter, Parm_CoilCrafter_Q1);
         break;
 
     case 290:
-        efx_CoilCrafter->changepar(5, 2600 + (int) ((float) value * C_MC_1900_RANGE));
+        efx_CoilCrafter->changepar(Parm_CoilCrafter_Freq2, 2600 + (int) ((float) value * C_MC_1900_RANGE));
+        preserve_parm(FX_CoilCrafter, Parm_CoilCrafter_Freq2);
         break;
 
     case 291:
-        efx_CoilCrafter->changepar(6, 10 + (int) ((float) value * C_MC_55_RANGE));
+        efx_CoilCrafter->changepar(Parm_CoilCrafter_Q2, 10 + (int) ((float) value * C_MC_55_RANGE));
+        preserve_parm(FX_CoilCrafter, Parm_CoilCrafter_Q2);
         break;
 
     case 292:
-        efx_ShelfBoost->changepar(0, value);
+        efx_ShelfBoost->changepar(Parm_Volume, value);
+        preserve_parm(FX_ShelfBoost, Parm_Volume);
         break;
 
     case 293:
-        efx_ShelfBoost->changepar(4, 1 + (int) ((float) value * C_MC_126_RANGE));
+        efx_ShelfBoost->changepar(Parm_ShelfBoost_Gain, 1 + (int) ((float) value * C_MC_126_RANGE));
+        preserve_parm(FX_ShelfBoost, Parm_ShelfBoost_Gain);
         break;
 
     case 294:
-        efx_ShelfBoost->changepar(2, 220 + (int) ((float) value * C_MC_15780_RANGE));
+        efx_ShelfBoost->changepar(Parm_ShelfBoost_Freq, 220 + (int) ((float) value * C_MC_15780_RANGE));
+        preserve_parm(FX_ShelfBoost, Parm_ShelfBoost_Freq);
         break;
 
     case 295:
-        efx_ShelfBoost->changepar(1, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        efx_ShelfBoost->changepar(Parm_MuTroMojo_Q, ((int) (float) value * C_MC_128_RANGE)  - 64);
+        preserve_parm(FX_ShelfBoost, Parm_MuTroMojo_Q);
         break;
 
     case 296:
-        efx_Vocoder->changepar(0, Dry_Wet(value));
+        efx_Vocoder->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Vocoder, Parm_DryWet);
         break;
 
     case 297:
-        efx_Vocoder->changepar(1, (int) ((float) value * C_MC_128_RANGE));
+        efx_Vocoder->changepar(Parm_Pan, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_Vocoder, Parm_Pan);
         break;
 
     case 298:
-        efx_Vocoder->changepar(4, value);
+        efx_Vocoder->changepar(Parm_Vocoder_Input, value);
+        preserve_parm(FX_Vocoder, Parm_Vocoder_Input);
         break;
 
     case 299:
-        efx_Vocoder->changepar(2, 1 + (int) ((float) value * C_MC_126_RANGE));
+        efx_Vocoder->changepar(Parm_Vocoder_Muffle, 1 + (int) ((float) value * C_MC_126_RANGE));
+        preserve_parm(FX_Vocoder, Parm_Vocoder_Muffle);
         break;
 
     case 300:
-        efx_Vocoder->changepar(3, 40 + (int) ((float) value * C_MC_130_RANGE));
+        efx_Vocoder->changepar(Parm_Vocoder_Q, 40 + (int) ((float) value * C_MC_130_RANGE));
+        preserve_parm(FX_Vocoder, Parm_Vocoder_Q);
         break;
 
     case 301:
-        efx_Vocoder->changepar(6, value);
+        efx_Vocoder->changepar(Parm_Vocoder_Ring, value);
+        preserve_parm(FX_Vocoder, Parm_Vocoder_Ring);
         break;
 
     case 302:
-        efx_Vocoder->changepar(5, value);
+        efx_Vocoder->changepar(Parm_Vocoder_Level, value);
+        preserve_parm(FX_Vocoder, Parm_Vocoder_Level);
         break;
 
     case 303:
-        efx_Echoverse->changepar(0, Dry_Wet(value));
+        efx_Echoverse->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Echoverse, Parm_DryWet);
         break;
 
     case 304:
-        efx_Echoverse->changepar(7, value);
+        efx_Echoverse->changepar(Parm_Arpie_Reverse, value);
+        preserve_parm(FX_Echoverse, Parm_Arpie_Reverse);
         break;
 
     case 305:
-        efx_Echoverse->changepar(1, value);
+        efx_Echoverse->changepar(Parm_Pan, value);
+        preserve_parm(FX_Echoverse, Parm_Pan);
         break;
 
     case 306:
-        efx_Echoverse->changepar(2, ret_Tempo(value));
+        efx_Echoverse->changepar(Parm_Echoverse_Delay, ret_Tempo(value));
+        preserve_parm(FX_Echoverse, Parm_Echoverse_Delay);
         break;
 
     case 307:
-        efx_Echoverse->changepar(3, value);
+        efx_Echoverse->changepar(Parm_Arpie_LRDelay, value);
+        preserve_parm(FX_Echoverse, Parm_Arpie_LRDelay);
         break;
 
     case 308:
-        efx_Echoverse->changepar(5, value);
+        efx_Echoverse->changepar(Parm_Feedback, value);
+        preserve_parm(FX_Echoverse, Parm_Feedback);
         break;
 
     case 309:
-        efx_Echoverse->changepar(6, value);
+        efx_Echoverse->changepar(Parm_Arpie_HiDamp, value);
+        preserve_parm(FX_Echoverse, Parm_Arpie_HiDamp);
         break;
 
     case 310:
-        efx_Echoverse->changepar(9, value);
+        efx_Echoverse->changepar(Parm_Echoverse_ExStereo, value);
+        preserve_parm(FX_Echoverse, Parm_Echoverse_ExStereo);
         break;
 
     case 311:
-        efx_Echoverse->changepar(4, (int) ((float) value * C_MC_128_RANGE));
+        efx_Echoverse->changepar(Parm_Echo_LRCross, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_Echoverse, Parm_Echo_LRCross);
         break;
 
     case 312:
-        efx_Sustainer->changepar(0, value);
+        efx_Sustainer->changepar(Parm_Volume, value);
+        preserve_parm(FX_Sustainer, Parm_Volume);
         break;
 
     case 313:
-        efx_Sustainer->changepar(1, value);
+        efx_Sustainer->changepar(Parm_Sustain, value);
+        preserve_parm(FX_Sustainer, Parm_Sustain);
         break;
 
     case 314:
-        efx_Sequence->changepar(8, Dry_Wet(value));
+        efx_Sequence->changepar(Parm_Sequence_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Sequence, Parm_Sequence_DryWet);
         break;
 
     case 315:
-        efx_Sequence->changepar(0, value);
+        efx_Sequence->changepar(Parm_Sequence_1, value);
+        preserve_parm(FX_Sequence, Parm_Sequence_1);
         break;
 
     case 316:
-        efx_Sequence->changepar(1, value);
+        efx_Sequence->changepar(Parm_Sequence_2, value);
+        preserve_parm(FX_Sequence, Parm_Sequence_2);
         break;
 
     case 317:
-        efx_Sequence->changepar(2, value);
+        efx_Sequence->changepar(Parm_Sequence_3, value);
+        preserve_parm(FX_Sequence, Parm_Sequence_3);
         break;
 
     case 318:
-        efx_Sequence->changepar(3, value);
+        efx_Sequence->changepar(Parm_Sequence_4, value);
+        preserve_parm(FX_Sequence, Parm_Sequence_4);
         break;
 
     case 319:
-        efx_Sequence->changepar(4, value);
+        efx_Sequence->changepar(Parm_Sequence_5, value);
+        preserve_parm(FX_Sequence, Parm_Sequence_5);
         break;
 
     case 320:
-        efx_Sequence->changepar(5, value);
+        efx_Sequence->changepar(Parm_Sequence_6, value);
+        preserve_parm(FX_Sequence, Parm_Sequence_6);
         break;
 
     case 321:
-        efx_Sequence->changepar(6, value);
+        efx_Sequence->changepar(Parm_Sequence_7, value);
+        preserve_parm(FX_Sequence, Parm_Sequence_7);
         break;
 
     case 322:
-        efx_Sequence->changepar(7, value);
+        efx_Sequence->changepar(Parm_Sequence_8, value);
+        preserve_parm(FX_Sequence, Parm_Sequence_8);
         break;
 
     case 323:
-        efx_Sequence->changepar(9, ret_Tempo(value));
+        efx_Sequence->changepar(Parm_Sequence_Tempo, ret_Tempo(value));
+        preserve_parm(FX_Sequence, Parm_Sequence_Tempo);
         break;
 
     case 324:
-        efx_Sequence->changepar(10, (int) ((float) value * C_MC_128_RANGE));
+        efx_Sequence->changepar(Parm_Sequence_Q, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_Sequence, Parm_Sequence_Q);
         break;
 
     case 325:
-        efx_Sequence->changepar(12, (int) ((float) value * C_MC_7_RANGE));
+        efx_Sequence->changepar(Parm_Sequence_StereoDiff, (int) ((float) value * C_MC_7_RANGE));
+        preserve_parm(FX_Sequence, Parm_Sequence_StereoDiff);
         break;
 
     case 326:
-        efx_Shifter->changepar(0, Dry_Wet(value));
+        efx_Shifter->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Shifter, Parm_DryWet);
         break;
 
     case 327:
-        efx_Shifter->changepar(6, (int) ((float) value * C_MC_12_RANGE));
+        efx_Shifter->changepar(Parm_Shifter_Interval, (int) ((float) value * C_MC_12_RANGE));
+        preserve_parm(FX_Shifter, Parm_Shifter_Interval);
         break;
 
     case 328:
-        efx_Shifter->changepar(2, value);
+        efx_Shifter->changepar(Parm_InputGain, value);
+        preserve_parm(FX_Shifter, Parm_InputGain);
         break;
 
     case 329:
-        efx_Shifter->changepar(1, value);
+        efx_Shifter->changepar(Parm_Pan, value);
+        preserve_parm(FX_Shifter, Parm_Pan);
         break;
 
     case 330:
-        efx_Shifter->changepar(3, 1 + (int) ((float) value * C_MC_1999_RANGE));
+        efx_Shifter->changepar(Parm_Expander_Attack, 1 + (int) ((float) value * C_MC_1999_RANGE));
+        preserve_parm(FX_Shifter, Parm_Expander_Attack);
         break;
 
     case 331:
-        efx_Shifter->changepar(4, 1 + (int) ((float) value * C_MC_1999_RANGE));
+        efx_Shifter->changepar(Parm_Expander_Decay, 1 + (int) ((float) value * C_MC_1999_RANGE));
+        preserve_parm(FX_Shifter, Parm_Expander_Decay);
         break;
 
     case 332:
-        efx_Shifter->changepar(5, -70 + (int) ((float) value * C_MC_90_RANGE));
+        efx_Shifter->changepar(Parm_Shifter_Threshold, -70 + (int) ((float) value * C_MC_90_RANGE));
+        preserve_parm(FX_Shifter, Parm_Shifter_Threshold);
         break;
 
     case 333:
-        efx_Shifter->changepar(9, value);
+        efx_Shifter->changepar(Parm_Shifter_Whammy, value);
+        preserve_parm(FX_Shifter, Parm_Shifter_Whammy);
         break;
 
     case 334:
-        efx_StompBox->changepar(0, value);
+        efx_StompBox->changepar(Parm_Volume, value);
+        preserve_parm(FX_StompBox, Parm_Volume);
         break;
 
     case 335:
-        efx_StompBox->changepar(4, value);
+        efx_StompBox->changepar(Parm_ShelfBoost_Gain, value);
+        preserve_parm(FX_StompBox, Parm_ShelfBoost_Gain);
         break;
 
     case 336:
-        efx_StompBox->changepar(3, (int) ((float) value * C_MC_128_RANGE));
+        efx_StompBox->changepar(Parm_StompBox_Low, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_StompBox, Parm_StompBox_Low);
         break;
 
     case 337:
-        efx_StompBox->changepar(2, (int) ((float) value * C_MC_128_RANGE));
+        efx_StompBox->changepar(Parm_StompBox_Mid, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_StompBox, Parm_StompBox_Mid);
         break;
 
     case 338:
-        efx_StompBox->changepar(1, (int) ((float) value * C_MC_128_RANGE));
+        efx_StompBox->changepar(Parm_StompBox_High, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_StompBox, Parm_StompBox_High);
         break;
 
     case 339:
-        efx_Reverbtron->changepar(0, Dry_Wet(value));
+        efx_Reverbtron->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Reverbtron, Parm_DryWet);
         break;
 
     case 340:
-        efx_Reverbtron->changepar(11, value);
+        efx_Reverbtron->changepar(Parm_Reverbtron_Pan, value);
+        preserve_parm(FX_Reverbtron, Parm_Reverbtron_Pan);
         break;
 
     case 341:
-        efx_Reverbtron->changepar(7, value);
+        efx_Reverbtron->changepar(Parm_Convolotron_Level, value);
+        preserve_parm(FX_Reverbtron, Parm_Convolotron_Level);
         break;
 
     case 342:
-        efx_Reverbtron->changepar(6, value);
+        efx_Reverbtron->changepar(Parm_Arpie_HiDamp, value);
+        preserve_parm(FX_Reverbtron, Parm_Arpie_HiDamp);
         break;
 
     case 343:
-        efx_Reverbtron->changepar(10, (int) ((float) value * C_MC_128_RANGE));
+        efx_Reverbtron->changepar(Parm_Convolotron_Feedback, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_Reverbtron, Parm_Convolotron_Feedback);
         break;
 
     case 344:
-        efx_Reverbtron->changepar(3, 20 + (int) ((float) value * C_MC_1480_RANGE));
+        efx_Reverbtron->changepar(Parm_Convolotron_Length, 20 + (int) ((float) value * C_MC_1480_RANGE));
+        preserve_parm(FX_Reverbtron, Parm_Convolotron_Length);
         break;
 
     case 345:
-        efx_Reverbtron->changepar(9, (int) ((float) value * C_MC_128_RANGE));
+        efx_Reverbtron->changepar(Parm_Reverbtron_Stretch, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_Reverbtron, Parm_Reverbtron_Stretch);
         break;
 
     case 346:
-        efx_Reverbtron->changepar(5, (int) ((float) value * C_MC_500_RANGE));
+        efx_Reverbtron->changepar(Parm_Reverbtron_InitialDelay, (int) ((float) value * C_MC_500_RANGE));
+        preserve_parm(FX_Reverbtron, Parm_Reverbtron_InitialDelay);
         break;
 
     case 347:
-        efx_Reverbtron->changepar(1, value);
+        efx_Reverbtron->changepar(Parm_Reverbtron_Fade, value);
+        preserve_parm(FX_Reverbtron, Parm_Reverbtron_Fade);
         break;
 
     case 348:
-        efx_Echotron->changepar(0, Dry_Wet(value));
+        efx_Echotron->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Echotron, Parm_DryWet);
         break;
 
     case 349:
-        efx_Echotron->changepar(11, value);
+        efx_Echotron->changepar(Parm_Reverbtron_Pan, value);
+        preserve_parm(FX_Echotron, Parm_Reverbtron_Pan);
         break;
 
     case 350:
-        efx_Echotron->changepar(5, ret_Tempo(value));
+        efx_Echotron->changepar(Parm_Echotron_Tempo, ret_Tempo(value));
+        preserve_parm(FX_Echotron, Parm_Echotron_Tempo);
         break;
 
     case 351:
-        efx_Echotron->changepar(6, value);
+        efx_Echotron->changepar(Parm_Arpie_HiDamp, value);
+        preserve_parm(FX_Echotron, Parm_Arpie_HiDamp);
         break;
 
     case 352:
-        efx_Echotron->changepar(10, value);
+        efx_Echotron->changepar(Parm_Convolotron_Feedback, value);
+        preserve_parm(FX_Echotron, Parm_Convolotron_Feedback);
         break;
 
     case 353:
-        efx_Echotron->changepar(7, value);
+        efx_Echotron->changepar(Parm_Echotron_LRCross, value);
+        preserve_parm(FX_Echotron, Parm_Echotron_LRCross);
         break;
 
     case 354:
-        efx_Echotron->changepar(2, value);
+        efx_Echotron->changepar(Parm_Echotron_Width, value);
+        preserve_parm(FX_Echotron, Parm_Echotron_Width);
         break;
 
     case 355:
-        efx_Echotron->changepar(1, value);
+        efx_Echotron->changepar(Parm_Echotron_Depth, value);
+        preserve_parm(FX_Echotron, Parm_Echotron_Depth);
         break;
 
     case 356:
-        efx_Echotron->changepar(9, value);
+        efx_Echotron->changepar(Parm_Echotron_LFOStereo, value);
+        preserve_parm(FX_Echotron, Parm_Echotron_LFOStereo);
         break;
 
     case 357:
@@ -2341,51 +2704,63 @@ RKR::process_midi_controller_events(int parameter, int value)
         {
             number_taps = efx_Echotron->File.fLength;
         }
-        efx_Echotron->changepar(3, number_taps);
+        efx_Echotron->changepar(Parm_Convolotron_Length, number_taps);
+        preserve_parm(FX_Echotron, Parm_Convolotron_Length);
         break;
     }
     case 358:
-        efx_StereoHarm->changepar(0, Dry_Wet(value));
+        efx_StereoHarm->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_StereoHarm, Parm_DryWet);
         break;
 
     case 359:
-        efx_StereoHarm->changepar(2, -12 + (int) ((float) value * C_MC_24_RANGE));
+        efx_StereoHarm->changepar(Parm_StereoHarm_IntervalLeft, -12 + (int) ((float) value * C_MC_24_RANGE));
+        preserve_parm(FX_StereoHarm, Parm_StereoHarm_IntervalLeft);
         break;
 
     case 360:
-        efx_StereoHarm->changepar(3, -2000 + (int) ((float) value * C_MC_4000_RANGE));
+        efx_StereoHarm->changepar(Parm_StereoHarm_ChromeLeft, -2000 + (int) ((float) value * C_MC_4000_RANGE));
+        preserve_parm(FX_StereoHarm, Parm_StereoHarm_ChromeLeft);
         break;
 
     case 361:
-        efx_StereoHarm->changepar(1, (int) ((float) value * C_MC_128_RANGE));
+        efx_StereoHarm->changepar(Parm_StereoHarm_GainLeft, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_StereoHarm, Parm_StereoHarm_GainLeft);
         break;
 
     case 362:
-        efx_StereoHarm->changepar(5, -12 + (int) ((float) value * C_MC_24_RANGE));
+        efx_StereoHarm->changepar(Parm_StereoHarm_IntervalRight, -12 + (int) ((float) value * C_MC_24_RANGE));
+        preserve_parm(FX_StereoHarm, Parm_StereoHarm_IntervalRight);
         break;
 
     case 363:
-        efx_StereoHarm->changepar(6, -2000 + (int) ((float) value * C_MC_4000_RANGE));
+        efx_StereoHarm->changepar(Parm_StereoHarm_ChromeRight, -2000 + (int) ((float) value * C_MC_4000_RANGE));
+        preserve_parm(FX_StereoHarm, Parm_StereoHarm_ChromeRight);
         break;
 
     case 364:
-        efx_StereoHarm->changepar(4, (int) ((float) value * C_MC_128_RANGE));
+        efx_StereoHarm->changepar(Parm_StereoHarm_GainRight, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_StereoHarm, Parm_StereoHarm_GainRight);
         break;
 
     case 365:
-        efx_StereoHarm->changepar(11, value);
+        efx_StereoHarm->changepar(Parm_StereoHarm_LRCross, value);
+        preserve_parm(FX_StereoHarm, Parm_StereoHarm_LRCross);
         break;
 
     case 366:
-        efx_StereoHarm->changepar(8, (int) ((float) value * C_MC_23_RANGE));
+        efx_StereoHarm->changepar(Parm_StereoHarm_Note, (int) ((float) value * C_MC_23_RANGE));
+        preserve_parm(FX_StereoHarm, Parm_StereoHarm_Note);
         break;
 
     case 367:
-        efx_StereoHarm->changepar(9, (int) ((float) value * C_MC_33_RANGE));
+        efx_StereoHarm->changepar(Parm_StereoHarm_Type, (int) ((float) value * C_MC_33_RANGE));
+        preserve_parm(FX_StereoHarm, Parm_StereoHarm_Type);
         break;
 
     case 368:
-        efx_CompBand->changepar(0, Dry_Wet(value));
+        efx_CompBand->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_CompBand, Parm_DryWet);
         break;
 
     case 369:
@@ -2393,407 +2768,508 @@ RKR::process_midi_controller_events(int parameter, int value)
         break;
 
     case 370:
-        efx_CompBand->changepar(1, 2 + (int) ((float) value * C_MC_40_RANGE));
+        efx_CompBand->changepar(Parm_CompBand_LowRatio, 2 + (int) ((float) value * C_MC_40_RANGE));
+        preserve_parm(FX_CompBand, Parm_CompBand_LowRatio);
         break;
 
     case 371:
-        efx_CompBand->changepar(2, 2 + (int) ((float) value * C_MC_40_RANGE));
+        efx_CompBand->changepar(Parm_CompBand_MidLowRatio, 2 + (int) ((float) value * C_MC_40_RANGE));
+        preserve_parm(FX_CompBand, Parm_CompBand_MidLowRatio);
         break;
 
     case 372:
-        efx_CompBand->changepar(3, 2 + (int) ((float) value * C_MC_40_RANGE));
+        efx_CompBand->changepar(Parm_CompBand_MidHighRatio, 2 + (int) ((float) value * C_MC_40_RANGE));
+        preserve_parm(FX_CompBand, Parm_CompBand_MidHighRatio);
         break;
 
     case 373:
-        efx_CompBand->changepar(4, 2 + (int) ((float) value * C_MC_40_RANGE));
+        efx_CompBand->changepar(Parm_CompBand_HighRatio, 2 + (int) ((float) value * C_MC_40_RANGE));
+        preserve_parm(FX_CompBand, Parm_CompBand_HighRatio);
         break;
 
     case 374:
-        efx_CompBand->changepar(5, -70 + (int) ((float) value * C_MC_94_RANGE));
+        efx_CompBand->changepar(Parm_CompBand_LowThreshold, -70 + (int) ((float) value * C_MC_94_RANGE));
+        preserve_parm(FX_CompBand, Parm_CompBand_LowThreshold);
         break;
 
     case 375:
-        efx_CompBand->changepar(6, -70 + (int) ((float) value * C_MC_94_RANGE));
+        efx_CompBand->changepar(Parm_CompBand_MidLowThreshold, -70 + (int) ((float) value * C_MC_94_RANGE));
+        preserve_parm(FX_CompBand, Parm_CompBand_MidLowThreshold);
         break;
 
     case 376:
-        efx_CompBand->changepar(7, -70 + (int) ((float) value * C_MC_94_RANGE));
+        efx_CompBand->changepar(Parm_CompBand_MidHighThreshold, -70 + (int) ((float) value * C_MC_94_RANGE));
+        preserve_parm(FX_CompBand, Parm_CompBand_MidHighThreshold);
         break;
 
     case 377:
-        efx_CompBand->changepar(8, -70 + (int) ((float) value * C_MC_94_RANGE));
+        efx_CompBand->changepar(Parm_CompBand_HighThreshold, -70 + (int) ((float) value * C_MC_94_RANGE));
+        preserve_parm(FX_CompBand, Parm_CompBand_HighThreshold);
         break;
 
     case 378:
-        efx_CompBand->changepar(9, 20 + (int) ((float) value * C_MC_980_RANGE));
+        efx_CompBand->changepar(Parm_CompBand_Cross1, 20 + (int) ((float) value * C_MC_980_RANGE));
+        preserve_parm(FX_CompBand, Parm_CompBand_Cross1);
         break;
 
     case 379:
-        efx_CompBand->changepar(10, 1000 + (int) ((float) value * C_MC_7000_RANGE));
+        efx_CompBand->changepar(Parm_CompBand_Cross2, 1000 + (int) ((float) value * C_MC_7000_RANGE));
+        preserve_parm(FX_CompBand, Parm_CompBand_Cross2);
         break;
 
     case 380:
-        efx_CompBand->changepar(11, 2000 + (int) ((float) value * C_MC_24000_RANGE));
+        efx_CompBand->changepar(Parm_CompBand_Cross3, 2000 + (int) ((float) value * C_MC_24000_RANGE));
+        preserve_parm(FX_CompBand, Parm_CompBand_Cross3);
         break;
 
     case 381:
-        efx_Opticaltrem->changepar(0, value);
+        efx_Opticaltrem->changepar(Parm_OpticalTrem_Depth, value);
+        preserve_parm(FX_OpticalTrem, Parm_OpticalTrem_Depth);
         break;
 
     case 382:
-        efx_Opticaltrem->changepar(1, ret_Tempo(value));
+        efx_Opticaltrem->changepar(Parm_VaryBand_LFOFreq, ret_Tempo(value));
+        preserve_parm(FX_OpticalTrem, Parm_VaryBand_LFOFreq);
         break;
 
     case 383:
-        efx_Opticaltrem->changepar(2, value);
+        efx_Opticaltrem->changepar(Parm_OpticalTrem_Randomness, value);
+        preserve_parm(FX_OpticalTrem, Parm_OpticalTrem_Randomness);
         break;
 
     case 384:
-        efx_Opticaltrem->changepar(4, value);
+        efx_Opticaltrem->changepar(Parm_OpticalTrem_LFOStereo, value);
+        preserve_parm(FX_OpticalTrem, Parm_OpticalTrem_LFOStereo);
         break;
 
     case 385:
-        efx_Opticaltrem->changepar(5, value);
+        efx_Opticaltrem->changepar(Parm_OpticalTrem_Pan, value);
+        preserve_parm(FX_OpticalTrem, Parm_OpticalTrem_Pan);
         break;
 
     case 386:
-        efx_Vibe->changepar(6, Dry_Wet(value));
+        efx_Vibe->changepar(Parm_Vibe_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Vibe, Parm_Vibe_DryWet);
         break;
 
     case 387:
-        efx_Vibe->changepar(0, value);
+        efx_Vibe->changepar(Parm_Vibe_Width, value);
+        preserve_parm(FX_Vibe, Parm_Vibe_Width);
         break;
 
     case 388:
-        efx_Vibe->changepar(8, value);
+        efx_Vibe->changepar(Parm_Vibe_Depth, value);
+        preserve_parm(FX_Vibe, Parm_Vibe_Depth);
         break;
 
     case 389:
-        efx_Vibe->changepar(1, ret_Tempo(value));
+        efx_Vibe->changepar(Parm_VaryBand_LFOFreq, ret_Tempo(value));
+        preserve_parm(FX_Vibe, Parm_VaryBand_LFOFreq);
         break;
 
     case 390:
-        efx_Vibe->changepar(2, value);
+        efx_Vibe->changepar(Parm_OpticalTrem_Randomness, value);
+        preserve_parm(FX_Vibe, Parm_OpticalTrem_Randomness);
         break;
 
     case 391:
-        efx_Vibe->changepar(4, value);
+        efx_Vibe->changepar(Parm_OpticalTrem_LFOStereo, value);
+        preserve_parm(FX_Vibe, Parm_OpticalTrem_LFOStereo);
         break;
 
     case 392:
-        efx_Vibe->changepar(7, (int) ((float) value * C_MC_128_RANGE));
+        efx_Vibe->changepar(Parm_Phaser_Feedback, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_Vibe, Parm_Phaser_Feedback);
         break;
 
     case 393:
-        efx_Vibe->changepar(9, (int) ((float) value * C_MC_128_RANGE));
+        efx_Vibe->changepar(Parm_LRCross, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_Vibe, Parm_LRCross);
         break;
 
     case 394:
-        efx_Vibe->changepar(5, (int) ((float) value * C_MC_128_RANGE));
+        efx_Vibe->changepar(Parm_OpticalTrem_Pan, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_Vibe, Parm_OpticalTrem_Pan);
         break;
 
     case 395:
-        efx_Infinity->changepar(0, Dry_Wet(value));
+        efx_Infinity->changepar(Parm_DryWet, Dry_Wet(value));
+        preserve_parm(FX_Infinity, Parm_DryWet);
         break;
 
     case 396:
-        efx_Infinity->changepar(9, -1000 + (int) ((float) value * C_MC_2000_RANGE));
+        efx_Infinity->changepar(Parm_Shuffle_Q, -1000 + (int) ((float) value * C_MC_2000_RANGE));
+        preserve_parm(FX_Infinity, Parm_Shuffle_Q);
         break;
 
     case 397:
-        efx_Infinity->changepar(15, value);
+        efx_Infinity->changepar(Parm_Infinity_Autopan, value);
+        preserve_parm(FX_Infinity, Parm_Infinity_Autopan);
         break;
 
     case 398:
-        efx_Infinity->changepar(13, (int) ((float) value * C_MC_128_RANGE));
+        efx_Infinity->changepar(Parm_Infinity_StereoDiff, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_Infinity, Parm_Infinity_StereoDiff);
         break;
 
     case 399:
-        efx_Infinity->changepar(10, value);
+        efx_Infinity->changepar(Parm_Infinity_StartFreq, value);
+        preserve_parm(FX_Infinity, Parm_Infinity_StartFreq);
         break;
 
     case 400:
-        efx_Infinity->changepar(11, value);
+        efx_Infinity->changepar(Parm_Infinity_EndFreq, value);
+        preserve_parm(FX_Infinity, Parm_Infinity_EndFreq);
         break;
 
     case 401:
-        efx_Infinity->changepar(12, ret_Tempo(value));
+        efx_Infinity->changepar(Parm_Infinity_Rate, ret_Tempo(value));
+        preserve_parm(FX_Infinity, Parm_Infinity_Rate);
         break;
 
     case 402:
-        efx_Infinity->changepar(14, -16 + (int) ((float) value * C_MC_32_RANGE));
+        efx_Infinity->changepar(Parm_Infinity_Subdiv, -16 + (int) ((float) value * C_MC_32_RANGE));
+        preserve_parm(FX_Infinity, Parm_Infinity_Subdiv);
         break;
 
     case 403:
-        efx_Alienwah->changepar(8, (int) ((float) value * C_MC_100_RANGE));
+        efx_Alienwah->changepar(Parm_Alien_Delay, (int) ((float) value * C_MC_100_RANGE));
+        preserve_parm(FX_Alienwah, Parm_Alien_Delay);
         break;
 
     case 404:
-        efx_APhaser->changepar(3, value);
+        efx_APhaser->changepar(Parm_LFORandomness, value);
+        preserve_parm(FX_APhaser, Parm_LFORandomness);
         break;
 
     case 405:
-        efx_Cabinet->changepar(0, value);
+        efx_Cabinet->changepar(Parm_Volume, value);
+        preserve_parm(FX_Cabinet, Parm_Volume);
         break;
 
     case 406:
-        efx_Chorus->changepar(7, value);
+        efx_Chorus->changepar(Parm_Chorus_Delay, value);
+        preserve_parm(FX_Chorus, Parm_Chorus_Delay);
         break;
     
     case 407:
-        efx_Echo->changepar(7, value);
+        efx_Echo->changepar(Parm_Arpie_Reverse, value);
+        preserve_parm(FX_Echo, Parm_Arpie_Reverse);
         break;
 
     case 408:
-        efx_Echo->changepar(2, 20 + (int) ((float) value * C_MC_1980_RANGE));
+        efx_Echo->changepar(Parm_Echoverse_Delay, 20 + (int) ((float) value * C_MC_1980_RANGE));
+        preserve_parm(FX_Echo, Parm_Echoverse_Delay);
         break;
 
     case 409:
-        efx_Echo->changepar(3, value);
+        efx_Echo->changepar(Parm_Arpie_LRDelay, value);
+        preserve_parm(FX_Echo, Parm_Arpie_LRDelay);
         break;
 
     case 410:
-        efx_Echo->changepar(6, value);
+        efx_Echo->changepar(Parm_Arpie_HiDamp, value);
+        preserve_parm(FX_Echo, Parm_Arpie_HiDamp);
         break;
 
     case 411:
-        efx_Flanger->changepar(7, value);
+        efx_Flanger->changepar(Parm_Chorus_Delay, value);
+        preserve_parm(FX_Flanger, Parm_Chorus_Delay);
         break;
         
     case 412:
-        efx_Har->changepar(2, value);
+        efx_Har->changepar(Parm_InputGain, value);
+        preserve_parm(FX_Harmonizer, Parm_InputGain);
         break;
 
     case 413:
-        efx_Har->changepar(8, value);
+        efx_Har->changepar(Parm_FGain, value);
+        preserve_parm(FX_Harmonizer, Parm_FGain);
         break;
 
     case 414:
-        efx_Har->changepar(9, value);
+        efx_Har->changepar(Parm_Shuffle_Q, value);
+        preserve_parm(FX_Harmonizer, Parm_Shuffle_Q);
         break;
 
     case 415:
-        efx_Infinity->changepar(1, (int) ((float) value * C_MC_128_RANGE));
+        efx_Infinity->changepar(Parm_Infinity_P1, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_Infinity, Parm_Infinity_P1);
         break;
 
     case 416:
-        efx_Infinity->changepar(2, (int) ((float) value * C_MC_128_RANGE));
+        efx_Infinity->changepar(Parm_Infinity_P2, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_Infinity, Parm_Infinity_P2);
         break;
 
     case 417:
-        efx_Infinity->changepar(3, (int) ((float) value * C_MC_128_RANGE));
+        efx_Infinity->changepar(Parm_Infinity_P3, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_Infinity, Parm_Infinity_P3);
         break;
 
     case 418:
-        efx_Infinity->changepar(4, (int) ((float) value * C_MC_128_RANGE));
+        efx_Infinity->changepar(Parm_Infinity_P4, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_Infinity, Parm_Infinity_P4);
         break;
 
     case 419:
-        efx_Infinity->changepar(5, (int) ((float) value * C_MC_128_RANGE));
+        efx_Infinity->changepar(Parm_Infinity_P5, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_Infinity, Parm_Infinity_P5);
         break;
 
     case 420:
-        efx_Infinity->changepar(6, (int) ((float) value * C_MC_128_RANGE));
+        efx_Infinity->changepar(Parm_Infinity_P6, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_Infinity, Parm_Infinity_P6);
         break;
 
     case 421:
-        efx_Infinity->changepar(7, (int) ((float) value * C_MC_128_RANGE));
+        efx_Infinity->changepar(Parm_Infinity_P7, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_Infinity, Parm_Infinity_P7);
         break;
 
     case 422:
-        efx_Infinity->changepar(8, (int) ((float) value * C_MC_128_RANGE));
+        efx_Infinity->changepar(Parm_Infinity_P8, (int) ((float) value * C_MC_128_RANGE));
+        preserve_parm(FX_Infinity, Parm_Infinity_P8);
         break;
 
     case 423:
-        efx_Looper->changepar(14, 20 + (int) ((float) value * C_MC_360_RANGE));
+        efx_Looper->changepar(Parm_Looper_Tempo, 20 + (int) ((float) value * C_MC_360_RANGE));
+        preserve_parm(FX_Looper, Parm_Looper_Tempo);
         break;
 
     case 424:
-        efx_MusDelay->changepar(10, 10 + (int) ((float) value * C_MC_470_RANGE));
+        efx_MusDelay->changepar(Parm_MusDelay_Tempo, 10 + (int) ((float) value * C_MC_470_RANGE));
+        preserve_parm(FX_MusDelay, Parm_MusDelay_Tempo);
         break;
 
     case 425:
-        efx_MusDelay->changepar(6, value);
+        efx_MusDelay->changepar(Parm_Arpie_HiDamp, value);
+        preserve_parm(FX_MusDelay, Parm_Arpie_HiDamp);
         break;
 
     case 426:
-        efx_MuTroMojo->changepar(3, value);
+        efx_MuTroMojo->changepar(Parm_LFORandomness, value);
+        preserve_parm(FX_MuTroMojo, Parm_LFORandomness);
         break;
 
     case 427:
-        efx_MuTroMojo->changepar(5, value);
+        efx_MuTroMojo->changepar(Parm_LFOStereo, value);
+        preserve_parm(FX_MuTroMojo, Parm_LFOStereo);
         break;
 
     case 428:
-        efx_MuTroMojo->changepar(15, 30 + (int) ((float) value * C_MC_770_RANGE));
+        efx_MuTroMojo->changepar(Parm_MuTroMojo_MinFreq, 30 + (int) ((float) value * C_MC_770_RANGE));
+        preserve_parm(FX_MuTroMojo, Parm_MuTroMojo_MinFreq);
         break;
 
     case 429:
-        efx_Gate->changepar(3, 1 + (int) ((float) value * C_MC_249_RANGE));
+        efx_Gate->changepar(Parm_Expander_Attack, 1 + (int) ((float) value * C_MC_249_RANGE));
+        preserve_parm(FX_Gate, Parm_Expander_Attack);
         break;
 
     case 430:
-        efx_Gate->changepar(4, 2 + (int) ((float) value * C_MC_248_RANGE));
+        efx_Gate->changepar(Parm_Expander_Decay, 2 + (int) ((float) value * C_MC_248_RANGE));
+        preserve_parm(FX_Gate, Parm_Expander_Decay);
         break;
 
     case 431:
-        efx_Gate->changepar(2, -90 + (int) ((float) value * C_MC_90_RANGE));
+        efx_Gate->changepar(Parm_Gate_Range, -90 + (int) ((float) value * C_MC_90_RANGE));
+        preserve_parm(FX_Gate, Parm_Gate_Range);
         break;
 
     case 432:
-        efx_Gate->changepar(1, -70 + (int) ((float) value * C_MC_90_RANGE));
+        efx_Gate->changepar(Parm_Threshold, -70 + (int) ((float) value * C_MC_90_RANGE));
+        preserve_parm(FX_Gate, Parm_Threshold);
         break;
 
     case 433:
-        efx_Gate->changepar(7, 2 + (int) ((float) value * C_MC_498_RANGE));
+        efx_Gate->changepar(Parm_Hold, 2 + (int) ((float) value * C_MC_498_RANGE));
+        preserve_parm(FX_Gate, Parm_Hold);
         break;
 
     case 434:
-        efx_Gate->changepar(5, ret_LPF(value));
+        efx_Gate->changepar(Parm_Expander_LowPassFilter, ret_LPF(value));
+        preserve_parm(FX_Gate, Parm_Expander_LowPassFilter);
         break;
 
     case 435:
-        efx_Gate->changepar(6, ret_HPF(value));
+        efx_Gate->changepar(Parm_Expander_HighPassFilter, ret_HPF(value));
+        preserve_parm(FX_Gate, Parm_Expander_HighPassFilter);
         break;
 
     case 436:
-        efx_Pan->changepar(6, value);
+        efx_Pan->changepar(Parm_Extra, value);
+        preserve_parm(FX_Pan, Parm_Extra);
         break;
 
     case 437:
-        efx_Rev->changepar(2, value);
+        efx_Rev->changepar(Parm_Reverb_Time, value);
+        preserve_parm(FX_Reverb, Parm_Reverb_Time);
         break;
 
     case 438:
-        efx_Rev->changepar(3, value);
+        efx_Rev->changepar(Parm_Reverb_InitialDelay, value);
+        preserve_parm(FX_Reverb, Parm_Reverb_InitialDelay);
         break;
 
     case 439:
-        efx_Rev->changepar(4, value);
+        efx_Rev->changepar(Parm_Reverb_DelayFeedback, value);
+        preserve_parm(FX_Reverb, Parm_Reverb_DelayFeedback);
         break;
 
     case 440:
-        efx_Rev->changepar(11, 1 + (int) ((float) value * C_MC_126_RANGE));
+        efx_Rev->changepar(Parm_Reverb_RoomSize, 1 + (int) ((float) value * C_MC_126_RANGE));
+        preserve_parm(FX_Reverb, Parm_Reverb_RoomSize);
         break;
 
     case 441:
-        efx_Rev->changepar(9, 64 + (int) ((float) value * C_MC_63_RANGE));
+        efx_Rev->changepar(Parm_Reverb_LoHiDamp, 64 + (int) ((float) value * C_MC_63_RANGE));
+        preserve_parm(FX_Reverb, Parm_Reverb_LoHiDamp);
         break;
 
     case 442:
-        efx_Reverbtron->changepar(15, value);
+        efx_Reverbtron->changepar(Parm_Reverbtron_Diffusion, value);
+        preserve_parm(FX_Reverbtron, Parm_Reverbtron_Diffusion);
         break;
 
     case 443:
-        efx_Reverbtron->changepar(14, ret_LPF(value));
+        efx_Reverbtron->changepar(Parm_Reverbtron_LowPassFilter, ret_LPF(value));
+        preserve_parm(FX_Reverbtron, Parm_Reverbtron_LowPassFilter);
         break;
 
     case 444:
-        efx_Har->changepar(6, (int) ((float) value * C_MC_23_RANGE));
+        efx_Har->changepar(Parm_Note, (int) ((float) value * C_MC_23_RANGE));
+        preserve_parm(FX_Harmonizer, Parm_Note);
         break;
 
     case 445:
-        efx_Har->changepar(7, (int) ((float) value * C_MC_33_RANGE));
+        efx_Har->changepar(Parm_Harmonizer_Type, (int) ((float) value * C_MC_33_RANGE));
+        preserve_parm(FX_Harmonizer, Parm_Harmonizer_Type);
         break;
 
     case 446:
-        efx_Synthfilter->changepar(3, value);
+        efx_Synthfilter->changepar(Parm_LFORandomness, value);
+        preserve_parm(FX_Synthfilter, Parm_LFORandomness);
         break;
 
     case 447:
-        efx_Har->changepar(5, value);
+        efx_Har->changepar(Parm_Harmonizer_Select, value);
+        preserve_parm(FX_Harmonizer, Parm_Harmonizer_Select);
         break;
 
     case 448:
-        efx_StereoHarm->changepar(7, value);
+        efx_StereoHarm->changepar(Parm_StereoHarm_Select, value);
+        preserve_parm(FX_StereoHarm, Parm_StereoHarm_Select);
         break;
 
     case 449:
-        efx_Distorsion->changepar(5, (int) ((float) value * C_MC_30_RANGE));
+        efx_Distorsion->changepar(Parm_Distortion_Type, (int) ((float) value * C_MC_30_RANGE));
+        preserve_parm(FX_Distortion, Parm_Distortion_Type);
         break;
 
     case 450:
-        efx_Overdrive->changepar(5, (int) ((float) value * C_MC_30_RANGE));
+        efx_Overdrive->changepar(Parm_Distortion_Type, (int) ((float) value * C_MC_30_RANGE));
+        preserve_parm(FX_Overdrive, Parm_Distortion_Type);
         break;
 
     case 451:
-        efx_Derelict->changepar(5, (int) ((float) value * C_MC_30_RANGE));
+        efx_Derelict->changepar(Parm_Distortion_Type, (int) ((float) value * C_MC_30_RANGE));
+        preserve_parm(FX_Derelict, Parm_Distortion_Type);
         break;
 
     case 452:
-        efx_DistBand->changepar(5, (int) ((float) value * C_MC_30_RANGE));
+        efx_DistBand->changepar(Parm_DistBand_TypeLow, (int) ((float) value * C_MC_30_RANGE));
+        preserve_parm(FX_DistBand, Parm_DistBand_TypeLow);
         break;
 
     case 453:
-        efx_DistBand->changepar(6, (int) ((float) value * C_MC_30_RANGE));
+        efx_DistBand->changepar(Parm_DistBand_TypeMid, (int) ((float) value * C_MC_30_RANGE));
+        preserve_parm(FX_DistBand, Parm_DistBand_TypeMid);
         break;
 
     case 454:
-        efx_DistBand->changepar(7, (int) ((float) value * C_MC_30_RANGE));
+        efx_DistBand->changepar(Parm_DistBand_TypeHigh, (int) ((float) value * C_MC_30_RANGE));
+        preserve_parm(FX_DistBand, Parm_DistBand_TypeHigh);
         break;
 
     case 455:
-        efx_StompBox->changepar(5, (int) ((float) value * C_MC_8_RANGE));
+        efx_StompBox->changepar(Parm_StompBox_Mode, (int) ((float) value * C_MC_8_RANGE));
+        preserve_parm(FX_StompBox, Parm_StompBox_Mode);
         break;
 
     case 456:
-        efx_Alienwah->changepar(4, (int) ((float) value * C_MC_11_RANGE));
+        efx_Alienwah->changepar(Parm_LFOType, (int) ((float) value * C_MC_11_RANGE));
+        preserve_parm(FX_Alienwah, Parm_LFOType);
         break;
 
     case 457:
-        efx_APhaser->changepar(4, (int) ((float) value * C_MC_11_RANGE));
+        efx_APhaser->changepar(Parm_LFOType, (int) ((float) value * C_MC_11_RANGE));
+        preserve_parm(FX_APhaser, Parm_LFOType);
         break;
 
     case 458:
-        efx_Chorus->changepar(4, (int) ((float) value * C_MC_11_RANGE));
+        efx_Chorus->changepar(Parm_LFOType, (int) ((float) value * C_MC_11_RANGE));
+        preserve_parm(FX_Chorus, Parm_LFOType);
         break;
 
     case 459:
-        efx_Flanger->changepar(4, (int) ((float) value * C_MC_11_RANGE));
+        efx_Flanger->changepar(Parm_LFOType, (int) ((float) value * C_MC_11_RANGE));
+        preserve_parm(FX_Flanger, Parm_LFOType);
         break;
 
     case 460:
-        efx_DFlange->changepar(12, (int) ((float) value * C_MC_11_RANGE));
+        efx_DFlange->changepar(Parm_DFlange_LFOType, (int) ((float) value * C_MC_11_RANGE));
+        preserve_parm(FX_DFlange, Parm_DFlange_LFOType);
         break;
 
     case 461:
-        efx_Echotron->changepar(14, (int) ((float) value * C_MC_11_RANGE));
+        efx_Echotron->changepar(Parm_Echotron_LFOType, (int) ((float) value * C_MC_11_RANGE));
+        preserve_parm(FX_Echotron, Parm_Echotron_LFOType);
         break;
 
     case 462:
-        efx_MuTroMojo->changepar(4, (int) ((float) value * C_MC_11_RANGE));
+        efx_MuTroMojo->changepar(Parm_LFOType, (int) ((float) value * C_MC_11_RANGE));
+        preserve_parm(FX_MuTroMojo, Parm_LFOType);
         break;
 
     case 463:
-        efx_Opticaltrem->changepar(3, (int) ((float) value * C_MC_11_RANGE));
+        efx_Opticaltrem->changepar(Parm_OpticalTrem_LFOType, (int) ((float) value * C_MC_11_RANGE));
+        preserve_parm(FX_OpticalTrem, Parm_OpticalTrem_LFOType);
         break;
 
     case 464:
-        efx_Pan->changepar(4, (int) ((float) value * C_MC_11_RANGE));
+        efx_Pan->changepar(Parm_LFOType, (int) ((float) value * C_MC_11_RANGE));
+        preserve_parm(FX_Pan, Parm_LFOType);
         break;
 
     case 465:
-        efx_Phaser->changepar(4, (int) ((float) value * C_MC_11_RANGE));
+        efx_Phaser->changepar(Parm_LFOType, (int) ((float) value * C_MC_11_RANGE));
+        preserve_parm(FX_Phaser, Parm_LFOType);
         break;
 
     case 466:
-        efx_Synthfilter->changepar(4, (int) ((float) value * C_MC_11_RANGE));
+        efx_Synthfilter->changepar(Parm_LFOType, (int) ((float) value * C_MC_11_RANGE));
+        preserve_parm(FX_Synthfilter, Parm_LFOType);
         break;
 
     case 467:
-        efx_VaryBand->changepar(2, (int) ((float) value * C_MC_11_RANGE));
+        efx_VaryBand->changepar(Parm_VaryBand_LFOType, (int) ((float) value * C_MC_11_RANGE));
+        preserve_parm(FX_VaryBand, Parm_VaryBand_LFOType);
         break;
 
     case 468:
-        efx_VaryBand->changepar(5, (int) ((float) value * C_MC_11_RANGE));
+        efx_VaryBand->changepar(Parm_VaryBand_LFO2Type, (int) ((float) value * C_MC_11_RANGE));
+        preserve_parm(FX_VaryBand, Parm_VaryBand_LFO2Type);
         break;
 
     case 469:
-        efx_Vibe->changepar(3, (int) ((float) value * C_MC_11_RANGE));
+        efx_Vibe->changepar(Parm_OpticalTrem_LFOType, (int) ((float) value * C_MC_11_RANGE));
+        preserve_parm(FX_Vibe, Parm_OpticalTrem_LFOType);
         break;
 
     case 470:
-        efx_WhaWha->changepar(4, (int) ((float) value * C_MC_11_RANGE));
+        efx_WhaWha->changepar(Parm_LFOType, (int) ((float) value * C_MC_11_RANGE));
+        preserve_parm(FX_WahWah, Parm_LFOType);
         break;
     }
 }


### PR DESCRIPTION
This fixes a race condition in the midi event processing.  When a midi control
change is sent, it took effect immediately.  Program changes occur
asynchronously.

This fix adds a map of booleans that indicate that a specific parameter should
not be overriden during a program change, thus effectively retaining
controller changes that occur while a program change is still pending.

This also replaces effect parameter numbers with symbolic constants (at least
in the midi event processing code).  This originally seemed like a good way to
protect the parameter values from exceeding the size of the per-effect array,
though this didn't work out well in practice.  I've retained this change
because the code is still more readable this way.

Finally, this adds "midicheck.py", a python script to verify that I haven't
changed any of the constants.  This should probably be removed from this PR
prior to merging.