### PR TITLE
Update rakarrack-plus.desktop

### DIFF
--- a/data/rakarrack-plus.desktop
+++ b/data/rakarrack-plus.desktop
@@ -1,8 +1,9 @@
 [Desktop Entry]
 Type=Application
-Categories=AudioVideo;Audio;
+Categories=AudioVideo;Audio;Music;
 Exec=rakarrack-plus
 Name=Rakarrack-Plus
+GenericName=Rakarrack-Plus
 Comment=Guitar Effects Processor
 Comment[fr]=Processeur d'effets de guitare
 Terminal=false


### PR DESCRIPTION
Some modifications to the .desktop file to stop complaints when building rakarrack-plus on openSUSE (the categories need a more specific subcategory and the GenericName field is needed)