### PR TITLE
Fix midi_converter LV2 required host features

### DIFF
--- a/lv2/rkrlv2.C
+++ b/lv2/rkrlv2.C
@@ -5469,7 +5469,7 @@ LV2_Handle init_midiclv2(const LV2_Descriptor* /* descriptor */,double sample_fr
 
     getFeatures(plug,host_features);
 
-    if(!plug->scheduler || !plug->urid_map)
+    if(!plug->urid_map)
     {
     //a required feature was not supported by host
     	free(plug);

--- a/lv2/ttl/midi_converter.ttl
+++ b/lv2/ttl/midi_converter.ttl
@@ -7,6 +7,7 @@
 @prefix param: <http://lv2plug.in/ns/ext/parameters#> .
 @prefix pset: <http://lv2plug.in/ns/ext/presets#> .
 @prefix atom:  <http://lv2plug.in/ns/ext/atom#> .
+@prefix urid:  <http://lv2plug.in/ns/ext/urid#> .
 @prefix lv2midi: <http://lv2plug.in/ns/ext/midi#> .
 
 @prefix lv2:   <http://lv2plug.in/ns/lv2core#> .
@@ -26,6 +27,7 @@
         lv2:minorVersion 0 ;
         lv2:microVersion 0 ;
         rdfs:comment "An experimental monophonic midi converter." ;
+        lv2:requiredFeature urid:map ;
         lv2:optionalFeature lv2:hardRTCapable ;
 #        ui:ui  <https://github.com/Stazed/rakarrack-plus#midi_converter_ui> ;
 


### PR DESCRIPTION
Fixes #34 

- required `urid:map` feature was missing in ttl
- don't require worker