### PR TITLE
2 fixes the menu's "Content Help" items

### DIFF
--- a/doc/help/help.html
+++ b/doc/help/help.html
@@ -20,9 +20,9 @@
   <tbody>
     <tr>
       <td>
-      <p><a href="https://Stazed@github.com/Stazed/rakarrack-plus"><img style="border: 2px solid ; width: 400px; height: 435px;" src="imagenes/Help_rakarrack-plus.png" alt="rakarrack-plus Logo" hspace="10"></a></p>
+      <p><a href="https://github.com/Stazed/rakarrack-plus"><img style="border: 2px solid ; width: 400px; height: 435px;" src="imagenes/Help_rakarrack-plus.png" alt="rakarrack-plus Logo" hspace="10"></a></p>
       </td>
-      <td bgcolor="#fbfbfb">
+      <td bgcolor="#888A85">
       <h1><b>Rakarrack-plus Help Contents</b></h1>
       <hr>
       <h3><a href="hardware.html">Hardware Connections</a></h3>


### PR DESCRIPTION
1. avoid having the toc written white on white
2. avoid the browser to display this message:
![rak+](https://user-images.githubusercontent.com/8705846/172044982-f86ee607-fb91-4647-a0c3-25f6ea1ed977.png)
